### PR TITLE
Feat auto detect available temp stream

### DIFF
--- a/EmotiBitOscilloscope/src/ofApp.cpp
+++ b/EmotiBitOscilloscope/src/ofApp.cpp
@@ -67,7 +67,7 @@ void ofApp::updateAvailableDataStreams(std::string typetag, bool addRemoveBar)
 {
 	if (typetag == EmotiBitPacket::TypeTag::THERMOPILE)
 	{
-		auto plotIdx = typeTagIndexes[EmotiBitPacket::TypeTag::TEMPERATURE_0];
+		auto plotIdx = typeTagIndexes[EmotiBitPacket::TypeTag::TEMPERATURE_1];
 		int w = plotIdx.at(0);
 		int s = plotIdx.at(1);
 		if (addRemoveBar)
@@ -1047,7 +1047,7 @@ void ofApp::setupOscilloscopes()
 			{ EmotiBitPacket::TypeTag::ACCELEROMETER_X, EmotiBitPacket::TypeTag::ACCELEROMETER_Y, EmotiBitPacket::TypeTag::ACCELEROMETER_Z },
 			{ EmotiBitPacket::TypeTag::GYROSCOPE_X, EmotiBitPacket::TypeTag::GYROSCOPE_Y, EmotiBitPacket::TypeTag::GYROSCOPE_Z },
 			{ EmotiBitPacket::TypeTag::MAGNETOMETER_X, EmotiBitPacket::TypeTag::MAGNETOMETER_Y, EmotiBitPacket::TypeTag::MAGNETOMETER_Z },
-			{ EmotiBitPacket::TypeTag::TEMPERATURE_0}
+			{ EmotiBitPacket::TypeTag::TEMPERATURE_1}
 			//{ EmotiBitPacket::TypeTag::TEMPERATURE_0 }
 		}
 	};
@@ -1098,7 +1098,7 @@ void ofApp::setupOscilloscopes()
 			{ "ACC:X", "ACC:Y", "ACC:Z" },
 			{ "GYRO:X", "GYRO:Y", "GYRO:Z" },
 			{ "MAG:X", "MAG:Y", "MAG:Z" },
-			{ "TEMP0"}
+			{ "TEMP1"}
 			//{ "TEMP0" }
 		}
 	};

--- a/EmotiBitOscilloscope/src/ofApp.cpp
+++ b/EmotiBitOscilloscope/src/ofApp.cpp
@@ -496,6 +496,7 @@ void ofApp::updateDeviceList()
 			ofRemoveListener(deviceGroup.parameterChangedE(), this, &ofApp::deviceGroupSelection);
 			device->set(false);
 			ofAddListener(deviceGroup.parameterChangedE(), this, &ofApp::deviceGroupSelection);
+			updateAvailableDataStreams(EmotiBitPacket::TypeTag::THERMOPILE, false);
 			clearOscilloscopes();
 		}
 	}
@@ -589,11 +590,13 @@ void ofApp::deviceGroupSelection(ofAbstractParameter& device)
 					vector<string> dataPackets;
 					emotiBitWiFi.readData(dataPackets);
 					emotiBitWiFi.readData(dataPackets);
+					updateAvailableDataStreams(EmotiBitPacket::TypeTag::THERMOPILE, false);
 					clearOscilloscopes();
 				}
 				// ToDo: consider if we need a delay here
 				emotiBitWiFi.connect(ip);
 				_powerMode = PowerMode::LOW_POWER;
+				updateAvailableDataStreams(EmotiBitPacket::TypeTag::THERMOPILE, false);
 				clearOscilloscopes();
 			}
 		}
@@ -609,6 +612,7 @@ void ofApp::deviceGroupSelection(ofAbstractParameter& device)
 			vector<string> dataPackets;
 			emotiBitWiFi.readData(dataPackets);
 			emotiBitWiFi.readData(dataPackets);
+			updateAvailableDataStreams(EmotiBitPacket::TypeTag::THERMOPILE, false);
 			clearOscilloscopes();
 		}
 	}
@@ -1232,7 +1236,7 @@ void ofApp::clearOscilloscopes()
 	for (int w = 0; w < scopeWins.size(); w++) {
 		scopeWins.at(w).clearData();
 	}
-	updateAvailableDataStreams(EmotiBitPacket::TypeTag::THERMOPILE, false);
+	
 	oscilloscopeStreamCountUpdated = false;
 }
 

--- a/EmotiBitOscilloscope/src/ofApp.cpp
+++ b/EmotiBitOscilloscope/src/ofApp.cpp
@@ -52,6 +52,28 @@ void ofApp::update() {
 	updateMenuButtons();
 }
 
+void ofApp::updateAvailableDataStreams(std::string typetag, bool addRemoveBar)
+{
+	if (typetag == EmotiBitPacket::TypeTag::TEMPERATURE_0)
+	{
+		if (addRemoveBar)
+		{
+			if (typeTagIndexes.find(EmotiBitPacket::TypeTag::TEMPERATURE_0) == typeTagIndexes.end())
+			{
+				typeTagIndexes.emplace(EmotiBitPacket::TypeTag::TEMPERATURE_0, typeTagIndexesTemplate[EmotiBitPacket::TypeTag::TEMPERATURE_0]);
+			}
+		}
+		else
+		{
+			if (typeTagIndexes.find(EmotiBitPacket::TypeTag::TEMPERATURE_0) != typeTagIndexes.end())
+			{
+				typeTagIndexes.erase(EmotiBitPacket::TypeTag::TEMPERATURE_0);
+				scopeWins.at(1).scopes.at(3).clearData();
+			}
+		}
+	}
+
+}
 //--------------------------------------------------------------
 void ofApp::draw() {
 	drawOscilloscopes();
@@ -167,6 +189,14 @@ void ofApp::keyReleased(int key) {
 			{
 				consoleLogger.stopThread();
 			}
+		}
+		if (key == 't')
+		{
+			updateAvailableDataStreams(EmotiBitPacket::TypeTag::TEMPERATURE_0, false);
+		}
+		if (key == 'T')
+		{
+			updateAvailableDataStreams(EmotiBitPacket::TypeTag::TEMPERATURE_0, true);
 		}
 		if (key == 'D')
 		{
@@ -986,7 +1016,7 @@ void ofApp::setupOscilloscopes()
 			{ EmotiBitPacket::TypeTag::ACCELEROMETER_X, EmotiBitPacket::TypeTag::ACCELEROMETER_Y, EmotiBitPacket::TypeTag::ACCELEROMETER_Z },
 			{ EmotiBitPacket::TypeTag::GYROSCOPE_X, EmotiBitPacket::TypeTag::GYROSCOPE_Y, EmotiBitPacket::TypeTag::GYROSCOPE_Z },
 			{ EmotiBitPacket::TypeTag::MAGNETOMETER_X, EmotiBitPacket::TypeTag::MAGNETOMETER_Y, EmotiBitPacket::TypeTag::MAGNETOMETER_Z },
-			{ EmotiBitPacket::TypeTag::THERMOPILE}
+			{ EmotiBitPacket::TypeTag::THERMOPILE, EmotiBitPacket::TypeTag::TEMPERATURE_0}
 			//{ EmotiBitPacket::TypeTag::TEMPERATURE_0 }
 		}
 	};
@@ -999,7 +1029,7 @@ void ofApp::setupOscilloscopes()
 			}
 		}
 	}
-
+	typeTagIndexesTemplate = typeTagIndexes;
 	bufferSizes = initBuffer(bufferSizes);
 	dataCounts = initBuffer(dataCounts);
 	dataFreqs = initBuffer(dataFreqs);
@@ -1037,7 +1067,7 @@ void ofApp::setupOscilloscopes()
 			{ "ACC:X", "ACC:Y", "ACC:Z" },
 			{ "GYRO:X", "GYRO:Y", "GYRO:Z" },
 			{ "MAG:X", "MAG:Y", "MAG:Z" },
-			{ "THERM"}
+			{ "THERM", "TEMP0"}
 			//{ "TEMP0" }
 		}
 	};
@@ -1091,7 +1121,7 @@ void ofApp::setupOscilloscopes()
 			{ofColor(255, 115, 0), ofColor(1, 204, 115), ofColor(4, 107, 183)},
 			{ofColor(255, 115, 0), ofColor(1, 204, 115), ofColor(4, 107, 183)},
 			{ofColor(255, 115, 0), ofColor(1, 204, 115), ofColor(4, 107, 183)},
-			{ofColor(239, 97, 82)}
+			{ofColor(239, 97, 82), ofColor(234, 174, 68)}
 			//{ofColor(234, 174, 68)}
 		}
 	};

--- a/EmotiBitOscilloscope/src/ofApp.cpp
+++ b/EmotiBitOscilloscope/src/ofApp.cpp
@@ -201,7 +201,7 @@ void ofApp::keyReleased(int key) {
 			drawDataInfo = !drawDataInfo;
 		}
 		if (key == OF_KEY_BACKSPACE || key == OF_KEY_DEL) {
-			clearOscilloscopes();
+			clearOscilloscopes(false);
 		}
 		if (key == ':')
 		{
@@ -496,8 +496,7 @@ void ofApp::updateDeviceList()
 			ofRemoveListener(deviceGroup.parameterChangedE(), this, &ofApp::deviceGroupSelection);
 			device->set(false);
 			ofAddListener(deviceGroup.parameterChangedE(), this, &ofApp::deviceGroupSelection);
-			updateAvailableDataStreams(EmotiBitPacket::TypeTag::THERMOPILE, false);
-			clearOscilloscopes();
+			clearOscilloscopes(true);
 		}
 	}
 }
@@ -590,14 +589,12 @@ void ofApp::deviceGroupSelection(ofAbstractParameter& device)
 					vector<string> dataPackets;
 					emotiBitWiFi.readData(dataPackets);
 					emotiBitWiFi.readData(dataPackets);
-					updateAvailableDataStreams(EmotiBitPacket::TypeTag::THERMOPILE, false);
-					clearOscilloscopes();
+					clearOscilloscopes(true);
 				}
 				// ToDo: consider if we need a delay here
 				emotiBitWiFi.connect(ip);
 				_powerMode = PowerMode::LOW_POWER;
-				updateAvailableDataStreams(EmotiBitPacket::TypeTag::THERMOPILE, false);
-				clearOscilloscopes();
+				clearOscilloscopes(true);
 			}
 		}
 	}
@@ -612,8 +609,7 @@ void ofApp::deviceGroupSelection(ofAbstractParameter& device)
 			vector<string> dataPackets;
 			emotiBitWiFi.readData(dataPackets);
 			emotiBitWiFi.readData(dataPackets);
-			updateAvailableDataStreams(EmotiBitPacket::TypeTag::THERMOPILE, false);
-			clearOscilloscopes();
+			clearOscilloscopes(true);
 		}
 	}
 }
@@ -1231,13 +1227,18 @@ void ofApp::updateLsl()
 	}
 }
 
-void ofApp::clearOscilloscopes()
+void ofApp::clearOscilloscopes(bool connectedDeviceUpdated)
 {
 	for (int w = 0; w < scopeWins.size(); w++) {
 		scopeWins.at(w).clearData();
 	}
-	
-	oscilloscopeStreamCountUpdated = false;
+
+	// update the Scope plots ONLY if there is update to connected device
+	if (connectedDeviceUpdated)
+	{
+		oscilloscopeStreamCountUpdated = false;
+		updateAvailableDataStreams(EmotiBitPacket::TypeTag::THERMOPILE, false);
+	}
 }
 
 void ofApp::updateMenuButtons()

--- a/EmotiBitOscilloscope/src/ofApp.cpp
+++ b/EmotiBitOscilloscope/src/ofApp.cpp
@@ -735,7 +735,7 @@ void ofApp::processSlowResponseMessage(vector<string> splitPacket)
 		}
 		if (ofGetSystemTimeMillis() - lastOscilloscopeCleared < 1000)
 		{
-			if (packetHeader.typeTag.compare(EmotiBitPacket::TypeTag::THERMOPILE))
+			if (packetHeader.typeTag.compare(EmotiBitPacket::TypeTag::THERMOPILE) == 0)
 			{
 				updateAvailableDataStreams(EmotiBitPacket::TypeTag::THERMOPILE, true);
 			}

--- a/EmotiBitOscilloscope/src/ofApp.cpp
+++ b/EmotiBitOscilloscope/src/ofApp.cpp
@@ -124,7 +124,7 @@ void ofApp::addDataStream(std::string typetag)
 		plotColors.at(w).at(s).emplace_back(typeTagPlotAttributes[typetag].typeTagColor);
 		typeTags.at(w).at(s).emplace_back(typetag);
 		// new plotIdx
-		int p = plotNames.at(w).at(s).size() - 1;
+		int p = plotNames.at(w).at(s).size() - 1; //  Size - 1 to make sure there is no out of bounds access.
 		std::vector<int> plotIdx = { w, s, p };
 		// update typetag Indexing
 		typeTagIndexes.emplace(typetag, plotIdx);
@@ -792,6 +792,7 @@ void ofApp::processSlowResponseMessage(vector<string> splitPacket)
 		{
 			_testingHelper.update(splitPacket, packetHeader);
 		}
+		// ToDo: the second comparison is redundant with the called func. Added it here to skip a function call. Might want to change the order later.
 		if (packetHeader.typeTag.compare(EmotiBitPacket::TypeTag::THERMOPILE) == 0 && typeTagIndexes.find(EmotiBitPacket::TypeTag::THERMOPILE) == typeTagIndexes.end())
 		{
 			// Add stream to plot if data detected.

--- a/EmotiBitOscilloscope/src/ofApp.cpp
+++ b/EmotiBitOscilloscope/src/ofApp.cpp
@@ -110,7 +110,7 @@ void ofApp::addDataStream(std::string typetag)
 {
 	if (typeTagIndexes.find(typetag) == typeTagIndexes.end())
 	{
-		// ToDo: Find a more elgant way to solve default plot state.
+		// ToDo: Find a more elegant way to solve default plot state.
 		// If adding THERM, remove default TEMP1. It will be added by separate add() call if Temp1 stream is found
 		if (typetag == EmotiBitPacket::TypeTag::THERMOPILE)
 		{
@@ -794,10 +794,12 @@ void ofApp::processSlowResponseMessage(vector<string> splitPacket)
 		}
 		if (packetHeader.typeTag.compare(EmotiBitPacket::TypeTag::THERMOPILE) == 0 && typeTagIndexes.find(EmotiBitPacket::TypeTag::THERMOPILE) == typeTagIndexes.end())
 		{
+			// Add stream to plot if data detected.
 			addDataStream(EmotiBitPacket::TypeTag::THERMOPILE);
 		}
 		if (packetHeader.typeTag.compare(EmotiBitPacket::TypeTag::TEMPERATURE_1) == 0 && typeTagIndexes.find(EmotiBitPacket::TypeTag::TEMPERATURE_1) == typeTagIndexes.end())
 		{
+			// Add stream to plot if data detected.
 			addDataStream(EmotiBitPacket::TypeTag::TEMPERATURE_1);
 		}
 		auto indexPtr = typeTagIndexes.find(packetHeader.typeTag);	// Check whether we're plotting this typeTage
@@ -1299,7 +1301,7 @@ void ofApp::clearOscilloscopes(bool connectedDeviceUpdated)
 	if (connectedDeviceUpdated)
 	{
 		// ToDo: think of an elegant way to set scopes to default value
-		// remove only THERM. TEMP1 is default for this scope.
+		// remove only THERM. TEMP1 is default for temperature scope..
 		removeDataStream(EmotiBitPacket::TypeTag::THERMOPILE);
 	}
 }

--- a/EmotiBitOscilloscope/src/ofApp.h
+++ b/EmotiBitOscilloscope/src/ofApp.h
@@ -57,7 +57,7 @@ public:
 	void setupGui();
 	void setupOscilloscopes();
 	void updateLsl();
-	void clearOscilloscopes();
+	void clearOscilloscopes(bool connectedDeviceUpdated);
 	void processModePacket(vector<string> &splitPacket);
 	void updateMenuButtons();
 	void drawConsole();

--- a/EmotiBitOscilloscope/src/ofApp.h
+++ b/EmotiBitOscilloscope/src/ofApp.h
@@ -63,6 +63,7 @@ public:
 	void drawConsole();
 	void drawOscilloscopes();
 	void updateAvailableDataStreams(std::string typetag, bool addRemoveBar);
+	void setTypeTagPlotAttributes();
 
 	//ofxMultiScope scopeWin;
 	//ofxMultiScope scopeWin2;
@@ -101,7 +102,7 @@ public:
 
 	EmotiBitWiFiHost emotiBitWiFi;
 	unordered_map<string, EmotiBitStatus> emotibitIps;
-
+	uint64_t lastOscilloscopeCleared;
 	//struct EmotibitPacketHeader_V1 {
 	//	uint32_t timestamp;  // milliseconds since EmotiBit bootup
 	//	uint16_t packetCount;
@@ -111,17 +112,21 @@ public:
 	//	uint8_t protocolVersion
 	//}
 
+	struct typeTagPlotAttr {
+		std::string tapeTagName;
+		ofColor typeTagColor;
+	};
 	vector<ofxMultiScope> scopeWins;
 	unordered_map<int, vector<size_t>> plotIdIndexes;
 	vector<vector<vector<string>>> typeTags;
 	unordered_map<string, vector<int>> typeTagIndexes;
-	unordered_map<string, vector<int>> typeTagIndexesTemplate;
 	vector<vector<float>> samplingFreqs;
 	vector<vector<vector<string>>> plotNames;
 	vector<vector<vector<float>>> yLims;
 	vector<vector<float>> minYSpans;
 	vector<vector<vector<ofColor>>> plotColors;
 	//vector<ofColor> plotColors;
+	unordered_map<std::string, typeTagPlotAttr>typeTagPlotAttributes;
 
 	vector<vector<vector<int>>> bufferSizes;
 	vector<vector<vector<int>>> dataCounts;

--- a/EmotiBitOscilloscope/src/ofApp.h
+++ b/EmotiBitOscilloscope/src/ofApp.h
@@ -106,7 +106,6 @@ public:
 
 	EmotiBitWiFiHost emotiBitWiFi;
 	unordered_map<string, EmotiBitStatus> emotibitIps;
-	bool oscilloscopeStreamCountUpdated = false;
 	//struct EmotibitPacketHeader_V1 {
 	//	uint32_t timestamp;  // milliseconds since EmotiBit bootup
 	//	uint16_t packetCount;

--- a/EmotiBitOscilloscope/src/ofApp.h
+++ b/EmotiBitOscilloscope/src/ofApp.h
@@ -63,6 +63,10 @@ public:
 	void drawConsole();
 	void drawOscilloscopes();
 	void updateAvailableDataStreams(std::string typetag, bool addRemoveBar);
+	void addDataStream(std::string typetag);
+	void removeDataStream(std::string typetag);
+	void reinitMetaDataBuffers();
+	void resetScopePlot(int w, int s);
 	void setTypeTagPlotAttributes();
 
 	//ofxMultiScope scopeWin;
@@ -115,6 +119,7 @@ public:
 	struct typeTagPlotAttr {
 		std::string tapeTagName;
 		ofColor typeTagColor;
+		vector<int> scopeIdx;
 	};
 	vector<ofxMultiScope> scopeWins;
 	unordered_map<int, vector<size_t>> plotIdIndexes;

--- a/EmotiBitOscilloscope/src/ofApp.h
+++ b/EmotiBitOscilloscope/src/ofApp.h
@@ -68,6 +68,7 @@ public:
 	void reinitMetaDataBuffers();
 	void resetScopePlot(int w, int s);
 	void setTypeTagPlotAttributes();
+	void resetIndexMapping();
 
 	//ofxMultiScope scopeWin;
 	//ofxMultiScope scopeWin2;

--- a/EmotiBitOscilloscope/src/ofApp.h
+++ b/EmotiBitOscilloscope/src/ofApp.h
@@ -62,6 +62,7 @@ public:
 	void updateMenuButtons();
 	void drawConsole();
 	void drawOscilloscopes();
+	void updateAvailableDataStreams(std::string typetag, bool addRemoveBar);
 
 	//ofxMultiScope scopeWin;
 	//ofxMultiScope scopeWin2;
@@ -114,6 +115,7 @@ public:
 	unordered_map<int, vector<size_t>> plotIdIndexes;
 	vector<vector<vector<string>>> typeTags;
 	unordered_map<string, vector<int>> typeTagIndexes;
+	unordered_map<string, vector<int>> typeTagIndexesTemplate;
 	vector<vector<float>> samplingFreqs;
 	vector<vector<vector<string>>> plotNames;
 	vector<vector<vector<float>>> yLims;

--- a/EmotiBitOscilloscope/src/ofApp.h
+++ b/EmotiBitOscilloscope/src/ofApp.h
@@ -62,7 +62,6 @@ public:
 	void updateMenuButtons();
 	void drawConsole();
 	void drawOscilloscopes();
-	void updateAvailableDataStreams(std::string typetag, bool addRemoveBar);
 	void addDataStream(std::string typetag);
 	void removeDataStream(std::string typetag);
 	void reinitMetaDataBuffers();

--- a/EmotiBitOscilloscope/src/ofApp.h
+++ b/EmotiBitOscilloscope/src/ofApp.h
@@ -102,7 +102,7 @@ public:
 
 	EmotiBitWiFiHost emotiBitWiFi;
 	unordered_map<string, EmotiBitStatus> emotibitIps;
-	uint64_t lastOscilloscopeCleared;
+	bool oscilloscopeStreamCountUpdated = false;
 	//struct EmotibitPacketHeader_V1 {
 	//	uint32_t timestamp;  // milliseconds since EmotiBit bootup
 	//	uint16_t packetCount;

--- a/EmotiBitOscilloscope/src/ofApp.h
+++ b/EmotiBitOscilloscope/src/ofApp.h
@@ -64,7 +64,7 @@ public:
 	void drawOscilloscopes();
 	void addDataStream(std::string typetag);
 	void removeDataStream(std::string typetag);
-	void reinitMetaDataBuffers();
+	void initMetaDataBuffers();
 	void resetScopePlot(int w, int s);
 	void setTypeTagPlotAttributes();
 	void resetIndexMapping();
@@ -89,7 +89,7 @@ public:
 	ofPoint max;
 
 	int selectedScope;
-
+	float timeWindowOnSetup; // seconds
 	bool isPaused;
 	ofSerial mySerial;
 
@@ -116,8 +116,8 @@ public:
 	//}
 
 	struct typeTagPlotAttr {
-		std::string tapeTagName;
-		ofColor typeTagColor;
+		std::string plotName;
+		ofColor plotColor;
 		vector<int> scopeIdx;
 	};
 	vector<ofxMultiScope> scopeWins;

--- a/src/ofxEmotiBitVersion.h
+++ b/src/ofxEmotiBitVersion.h
@@ -1,7 +1,7 @@
 #pragma once
 //#include <string>
 #include "ofMain.h"
-const std::string ofxEmotiBitVersion = "1.2.7";
+const std::string ofxEmotiBitVersion = "1.2.8";
 
 static void writeOfxEmotiBitVersionFile() {
 	string filename = "ofxEmotiBit_Version.txt";

--- a/src/ofxEmotiBitVersion.h
+++ b/src/ofxEmotiBitVersion.h
@@ -1,7 +1,7 @@
 #pragma once
 //#include <string>
 #include "ofMain.h"
-const std::string ofxEmotiBitVersion = "1.2.5";
+const std::string ofxEmotiBitVersion = "1.2.5-testTempPlot";
 
 static void writeOfxEmotiBitVersionFile() {
 	string filename = "ofxEmotiBit_Version.txt";

--- a/src/ofxEmotiBitVersion.h
+++ b/src/ofxEmotiBitVersion.h
@@ -1,7 +1,7 @@
 #pragma once
 //#include <string>
 #include "ofMain.h"
-const std::string ofxEmotiBitVersion = "1.2.8";
+const std::string ofxEmotiBitVersion = "1.2.9";
 
 static void writeOfxEmotiBitVersionFile() {
 	string filename = "ofxEmotiBit_Version.txt";

--- a/src/ofxEmotiBitVersion.h
+++ b/src/ofxEmotiBitVersion.h
@@ -1,7 +1,7 @@
 #pragma once
 //#include <string>
 #include "ofMain.h"
-const std::string ofxEmotiBitVersion = "1.2.6";
+const std::string ofxEmotiBitVersion = "1.2.7";
 
 static void writeOfxEmotiBitVersionFile() {
 	string filename = "ofxEmotiBit_Version.txt";

--- a/src/ofxEmotiBitVersion.h
+++ b/src/ofxEmotiBitVersion.h
@@ -1,7 +1,7 @@
 #pragma once
 //#include <string>
 #include "ofMain.h"
-const std::string ofxEmotiBitVersion = "1.2.5-testTempPlot";
+const std::string ofxEmotiBitVersion = "1.2.6";
 
 static void writeOfxEmotiBitVersionFile() {
 	string filename = "ofxEmotiBit_Version.txt";


### PR DESCRIPTION
# Description
- Automatically detects and displays available Temperature streams for EmotiBit V4.
- The temperature scope defaults to TEMP1. If therm is detected, Therm is added.

# Requirements
- https://github.com/produceconsumerobot/ofxOscilloscope/pull/4
- https://github.com/EmotiBit/EmotiBit_XPlat_Utils/pull/14


# Testing

| Firmware Version  | V4-EM | V4-MD | V3 | V2 |
| ------------------ | -----|------ | --- | --  |
| 1.3.11 | T1| TH+T1 | TH + T1| TH + T1| 
| 1.3.6(and below) | - (empty T1 plot) | TH |  TH | TH |