### PR TITLE
changed column header from EpochTimestamp to LocalTimestamp in parsed files

### DIFF
--- a/EmotiBitDataParser/src/ofApp.cpp
+++ b/EmotiBitDataParser/src/ofApp.cpp
@@ -680,7 +680,7 @@ void ofApp::parseDataLine(string packet) {
 					loggers.emplace(typeTag, new LoggerThread("", outFilePath));
 					loggerPtr = loggers.find(typeTag);
 					loggerPtr->second->startThread();
-					loggerPtr->second->push("EpochTimestamp,EmotiBitTimestamp,PacketNumber,DataLength,TypeTag,ProtocolVersion,DataReliability," + typeTag + "\n");
+					loggerPtr->second->push("LocalTimestamp,EmotiBitTimestamp,PacketNumber,DataLength,TypeTag,ProtocolVersion,DataReliability," + typeTag + "\n");
 				}
 				bool isAperiodicType = false;
 				for (int i = 0; i < EmotiBitPacket::TypeTagGroups::NUM_APERIODIC; i++)

--- a/src/ofxEmotiBitVersion.h
+++ b/src/ofxEmotiBitVersion.h
@@ -1,7 +1,7 @@
 #pragma once
 //#include <string>
 #include "ofMain.h"
-const std::string ofxEmotiBitVersion = "1.4.3";
+const std::string ofxEmotiBitVersion = "1.4.4";
 
 static void writeOfxEmotiBitVersionFile() {
 	string filename = "ofxEmotiBit_Version.txt";


### PR DESCRIPTION
# Description
Minor fix that changes columns header in parsed files.
- `EpochTimestamp` changed to `LocalTimestamp`