### PR TITLE
Fix sw version checker

### DIFF
--- a/EmotiBitOscilloscope/src/ofApp.cpp
+++ b/EmotiBitOscilloscope/src/ofApp.cpp
@@ -61,8 +61,9 @@ void ofApp::checkLatestSwVersion()
 {
 	bool newVersionAvailable = false;
 	// system call to curl
-	std::string latestReleaseUrl = "https://api.github.com/repos/EmotiBit/ofxEmotiBit/releases/latest";
-	std::string command = "curl " + latestReleaseUrl;
+	std::string latestReleaseUrl = "https://github.com/EmotiBit/ofxEmotiBit/releases/latest";
+	std::string latestReleaseApiRequest = "https://api.github.com/repos/EmotiBit/ofxEmotiBit/releases/latest";
+	std::string command = "curl " + latestReleaseApiRequest;
 	std::string response = "";
 	char buffer[200];
 	bool exceptionOccured = false;

--- a/EmotiBitOscilloscope/src/ofApp.cpp
+++ b/EmotiBitOscilloscope/src/ofApp.cpp
@@ -129,7 +129,7 @@ void ofApp::checkLatestSwVersion()
 			ofxJSONElement jsonResponse;
 			if (jsonResponse.parse(response))
 			{
-				ofLog(OF_LOG_NOTICE, jsonResponse.getRawString(true));
+				//ofLog(OF_LOG_NOTICE, jsonResponse.getRawString(true));  // uncomment to print curl output
 				std::string latestAvailableVersion = jsonResponse["tag_name"].asString();
 				ofLogNotice("Latest version") << latestAvailableVersion;
 				int swVerPrefixLoc = latestAvailableVersion.find(SOFTWARE_VERSION_PREFIX);

--- a/src/ofxEmotiBitVersion.h
+++ b/src/ofxEmotiBitVersion.h
@@ -1,8 +1,8 @@
 #pragma once
 //#include <string>
 #include "ofMain.h"
-const std::string ofxEmotiBitVersion = "1.4.4.fix-SwVersionChecker-1";
-
+const std::string ofxEmotiBitVersion = "1.4.4.fix-SwVersionChecker-2";
+static const char SOFTWARE_VERSION_PREFIX = 'v';
 static void writeOfxEmotiBitVersionFile() {
 	string filename = "ofxEmotiBit_Version.txt";
 	remove(ofToDataPath(filename).c_str());

--- a/src/ofxEmotiBitVersion.h
+++ b/src/ofxEmotiBitVersion.h
@@ -1,7 +1,7 @@
 #pragma once
 //#include <string>
 #include "ofMain.h"
-const std::string ofxEmotiBitVersion = "1.4.4.feat-advertisingOptions.8";
+const std::string ofxEmotiBitVersion = "1.4.4.fix-SwVersionChecker-1";
 
 static void writeOfxEmotiBitVersionFile() {
 	string filename = "ofxEmotiBit_Version.txt";

--- a/src/ofxEmotiBitVersion.h
+++ b/src/ofxEmotiBitVersion.h
@@ -1,7 +1,7 @@
 #pragma once
 //#include <string>
 #include "ofMain.h"
-const std::string ofxEmotiBitVersion = "1.4.4.fix-SwVersionChecker-2";
+const std::string ofxEmotiBitVersion = "1.4.4.fix-SwVersionChecker-3";
 static const char SOFTWARE_VERSION_PREFIX = 'v';
 static void writeOfxEmotiBitVersionFile() {
 	string filename = "ofxEmotiBit_Version.txt";


### PR DESCRIPTION
# description
- fixed latest SW version check
  - Now uses information grabbed from github REST api to figure out version of latest release

# references
- One Liner to Download the Latest Release from Github Repo: https://gist.github.com/steinwaywhw/a4cd19cda655b8249d908261a62687f8
- Getting started with the REST API - GitHub Docs: https://docs.github.com/en/rest/guides/getting-started-with-the-rest-api