### PR TITLE
Added fix to update OSC in "send data via"

### DIFF
--- a/EmotiBitOscilloscope/src/ofApp.cpp
+++ b/EmotiBitOscilloscope/src/ofApp.cpp
@@ -856,8 +856,10 @@ void ofApp::sendDataSelection(ofAbstractParameter& output) {
 
 	string outputName = output.getName();
 	bool selected = output.cast<bool>().get();
-
+	std::string previousList = sendOptionSelected.getParameter().toString();
+	std::string newSendType = "";
 	for (int j = 0; j < sendDataList.size(); j++) {
+		// if the Tx type is disabled, do nothing
 		if (sendDataDisabled.at(j))
 		{
 			if (selected)
@@ -872,6 +874,8 @@ void ofApp::sendDataSelection(ofAbstractParameter& output) {
 			{
 				if (GUI_STRING_SEND_DATA_OSC.compare(sendDataOptions.at(j)) == 0)
 				{
+					// update "send via:" string
+					newSendType = GUI_STRING_SEND_DATA_OSC;
 					if (selected)
 					{
 						string patchboardFile = "oscOutputSettings.xml";
@@ -883,14 +887,17 @@ void ofApp::sendDataSelection(ofAbstractParameter& output) {
 								<< "," << ofToInt(oscPatchboard.settings.output["port"]) << endl;
 								oscSender.setup(oscPatchboard.settings.output["ipAddress"], ofToInt(oscPatchboard.settings.output["port"]));
 							sendOsc = true;
+							sendOptionSelected.setup(GUI_STRING_SEND_DATA_VIA, newSendType);
 						}
 						catch (exception e)
 						{
 							cout << "OSC output setup failed " << endl;
+							sendOptionSelected.setup(GUI_STRING_SEND_DATA_VIA, previousList);
 						}
 					}
 					else
 					{
+						sendOptionSelected.setup(GUI_STRING_SEND_DATA_VIA, GUI_STRING_SEND_DATA_NONE);
 						sendOsc = false;
 					}
 				}

--- a/EmotiBitOscilloscope/src/ofApp.cpp
+++ b/EmotiBitOscilloscope/src/ofApp.cpp
@@ -856,8 +856,6 @@ void ofApp::sendDataSelection(ofAbstractParameter& output) {
 
 	string outputName = output.getName();
 	bool selected = output.cast<bool>().get();
-	std::string previousList = sendOptionSelected.getParameter().toString();
-	std::string newSendType = "";
 	for (int j = 0; j < sendDataList.size(); j++) {
 		// if the Tx type is disabled, do nothing
 		if (sendDataDisabled.at(j))
@@ -874,8 +872,6 @@ void ofApp::sendDataSelection(ofAbstractParameter& output) {
 			{
 				if (GUI_STRING_SEND_DATA_OSC.compare(sendDataOptions.at(j)) == 0)
 				{
-					// update "send via:" string
-					newSendType = GUI_STRING_SEND_DATA_OSC;
 					if (selected)
 					{
 						string patchboardFile = "oscOutputSettings.xml";
@@ -887,24 +883,42 @@ void ofApp::sendDataSelection(ofAbstractParameter& output) {
 								<< "," << ofToInt(oscPatchboard.settings.output["port"]) << endl;
 								oscSender.setup(oscPatchboard.settings.output["ipAddress"], ofToInt(oscPatchboard.settings.output["port"]));
 							sendOsc = true;
-							sendOptionSelected.setup(GUI_STRING_SEND_DATA_VIA, newSendType);
+							
 						}
 						catch (exception e)
 						{
 							cout << "OSC output setup failed " << endl;
-							sendOptionSelected.setup(GUI_STRING_SEND_DATA_VIA, previousList);
+							sendDataList.at(j).set(false);
+							sendOsc = false;
 						}
 					}
 					else
 					{
-						sendOptionSelected.setup(GUI_STRING_SEND_DATA_VIA, GUI_STRING_SEND_DATA_NONE);
 						sendOsc = false;
 					}
 				}
 			}
 		}
 	}
-
+	bool isSending = false;
+	// check if we are sending data out on any channel
+	for (int i = 0; i < sendDataList.size(); i++)
+	{
+		if (sendDataList.at(i).get())
+		{
+			// we are sending data on some channel
+			isSending = true;
+			break;
+		}
+	}
+	if (isSending)
+	{
+		sendOptionSelected.setup(GUI_STRING_SEND_DATA_VIA, "");
+	}
+	else
+	{
+		sendOptionSelected.setup(GUI_STRING_SEND_DATA_VIA, GUI_STRING_SEND_DATA_NONE);
+	}
 	return;  
 #if (0)
 	if (selected) {

--- a/src/ofxEmotiBitVersion.h
+++ b/src/ofxEmotiBitVersion.h
@@ -2,7 +2,7 @@
 //#include <string>
 #include "ofMain.h"
 
-const std::string ofxEmotiBitVersion = "1.5.2.fixSendVia.0";
+const std::string ofxEmotiBitVersion = "1.5.2.fixSendVia.1";
 static const char SOFTWARE_VERSION_PREFIX = 'v';
 
 static void writeOfxEmotiBitVersionFile() {

--- a/src/ofxEmotiBitVersion.h
+++ b/src/ofxEmotiBitVersion.h
@@ -2,7 +2,7 @@
 //#include <string>
 #include "ofMain.h"
 
-const std::string ofxEmotiBitVersion = "1.5.2";
+const std::string ofxEmotiBitVersion = "1.5.2.fixSendVia.0";
 static const char SOFTWARE_VERSION_PREFIX = 'v';
 
 static void writeOfxEmotiBitVersionFile() {


### PR DESCRIPTION
# Description
- fixes GUI issue where selecting OSC output does not update "send data via" field
# Issues referenced
- closes #138 

# To Test
- Click on the OSC button.
  - The `send data via` field removes the keyword `None` from display

# Screenshots
- ![image](https://user-images.githubusercontent.com/31810812/180868056-eb8d711d-12f8-446c-b269-964c7d17dbb6.png)
- ![image](https://user-images.githubusercontent.com/31810812/180868095-5d6ceecd-0401-4596-83be-e70ef63596c4.png)
