### PR TITLE
Fix user note parse

### DIFF
--- a/EmotiBitDataParser/src/ofApp.cpp
+++ b/EmotiBitDataParser/src/ofApp.cpp
@@ -1195,13 +1195,16 @@ void ofApp::parseDataLine(string packet) {
 							{
 								parsedDataRow += ofToString((long double)c, 6) + ",";
 							}
-							long double newDomainTimestamp;
-							newDomainTimestamp = linterp((long double)c,
-								timeSyncMap.anchorPoints[EmotiBitPacket::TypeTag::TIMESTAMP_LOCAL].first,
-								timeSyncMap.anchorPoints[EmotiBitPacket::TypeTag::TIMESTAMP_LOCAL].second,
-								timeSyncMap.anchorPoints[newTimeDomain].first,
-								timeSyncMap.anchorPoints[newTimeDomain].second);
-							parsedDataRow = ofToString(newDomainTimestamp, 6) + "," + parsedDataRow;
+							else
+							{
+								long double newDomainTimestamp;
+								newDomainTimestamp = linterp((long double)c,
+									timeSyncMap.anchorPoints[EmotiBitPacket::TypeTag::TIMESTAMP_LOCAL].first,
+									timeSyncMap.anchorPoints[EmotiBitPacket::TypeTag::TIMESTAMP_LOCAL].second,
+									timeSyncMap.anchorPoints[newTimeDomain].first,
+									timeSyncMap.anchorPoints[newTimeDomain].second);
+								parsedDataRow = ofToString(newDomainTimestamp, 6) + "," + parsedDataRow;
+							}
 						}
 						loggerPtr->second->push(
 							parsedDataRow + ofToString(timestamp, 3) + "," +

--- a/src/ofxEmotiBitVersion.h
+++ b/src/ofxEmotiBitVersion.h
@@ -2,7 +2,7 @@
 //#include <string>
 #include "ofMain.h"
 
-const std::string ofxEmotiBitVersion = "1.5.3.fix-partialParse.5";
+const std::string ofxEmotiBitVersion = "1.5.3.fix-partialParse.5.fix-UserNotes.0";
 static const char SOFTWARE_VERSION_PREFIX = 'v';
 
 static void writeOfxEmotiBitVersionFile() {


### PR DESCRIPTION
# Description
Fixes a bug that was causing an error in parsing user notes.

# Requirements
- Close `fix-partialparse PR` (link URL after PR has been created)


# Issues Referenced
<!-- If Any -->
- Fixes #156 


# Testing

**Test Configuration**:
```
{
    "info": {
      "name": "EmotiBitData",
      "type": "Multimodal",
      "source_id": "EmotiBit FeatherWing",
      "hardware_version": "V04a",
      "sku": "MD",
      "device_id": "MD-V4-0000475",
      "feather_version": "Adafruit Feather HUZZAH32",
      "feather_wifi_mac_addr": "0c:ff:d8:bd:9e:7c",
      "firmware_version": "1.3.36.feat-Esp.37-TC",
      "created_at": "2022-07-25_16-00-11-268166"
    }
  },
```
* EmotiBit software version: `1.5.3.fix-partialParse.5.fix-UserNotes.0`

|Test | Result | Link |
|-----|--------|------|
|Parsing with LSL conversions | ![image](https://user-images.githubusercontent.com/31810812/180865849-56f2d976-42c4-480f-b220-129370ae1a4f.png)| - |
|Parsing without LSL conversion| ![image](https://user-images.githubusercontent.com/31810812/180865636-f0eb1274-4f8e-41c0-9f76-b85bf7220ed0.png)| - | 

# Checklist:

- [ ] doxygen style comments included
- [ ] Required documentation udpated

## Screenshots:
