### PR TITLE
Fix partial parse

### DIFF
--- a/EmotiBitDataParser/src/ofApp.cpp
+++ b/EmotiBitDataParser/src/ofApp.cpp
@@ -763,15 +763,19 @@ void ofApp::draw() {
 //--------------------------------------------------------------
 void  ofApp::closeLoggers() {
 	for (auto it = loggers.cbegin(); it != loggers.cend(); ++it) {
-		ofLog(OF_LOG_VERBOSE, it->first
+		string out = "";
+		out +=it->first
 			+ " push: " + ofToString(it->second->size(LoggerThread::LoggerQueue::PUSH))
-			+ ", pop: " + ofToString(it->second->size(LoggerThread::LoggerQueue::POP)));
+			+ ", pop: " + ofToString(it->second->size(LoggerThread::LoggerQueue::POP));
 
+		out += ", stopThread()";
 		it->second->stopThread();
 
-		ofLog(OF_LOG_VERBOSE, it->first
-			+ " push: " + ofToString(it->second->size(LoggerThread::LoggerQueue::PUSH))
-			+ ", pop: " + ofToString(it->second->size(LoggerThread::LoggerQueue::POP)));
+		out += 
+			", push: " + ofToString(it->second->size(LoggerThread::LoggerQueue::PUSH))
+			+ ", pop: " + ofToString(it->second->size(LoggerThread::LoggerQueue::POP));
+
+		ofLog(OF_LOG_VERBOSE, out);
 		delete it->second;
 	}
 
@@ -780,7 +784,7 @@ void  ofApp::closeLoggers() {
 
 //--------------------------------------------------------------
 void ofApp::exit() {
-	printf("exit()");
+	ofLog(OF_LOG_NOTICE, "exit()");
 	closeLoggers();
 }
 

--- a/EmotiBitDataParser/src/ofApp.cpp
+++ b/EmotiBitDataParser/src/ofApp.cpp
@@ -6,6 +6,7 @@
 //--------------------------------------------------------------
 void ofApp::setup() {
 	ofLogToConsole();
+	ofSetLogLevel(OF_LOG_VERBOSE);
 #ifdef TARGET_MAC_OS
     ofSetDataPathRoot("../Resources/");
     cout<<"Changed the data pathroot for Release"<<endl;
@@ -146,10 +147,7 @@ void ofApp::startProcessing(bool & processing) {
 		if (inFile.is_open()) {
 			inFile.close();
 		}
-		for (auto it = loggers.cbegin(); it != loggers.cend(); ++it) {
-			delete it->second;
-		}
-		loggers.clear();
+		closeLoggers();
 		currentState = State::IDLE;
 	}
 }
@@ -254,6 +252,7 @@ void ofApp::update() {
 		}
 		else
 		{
+			closeLoggers();
 			processStatus.getParameter().fromString(GUI_STATUS_IDLE);
 		}
 	}
@@ -762,13 +761,27 @@ void ofApp::draw() {
 }
 
 //--------------------------------------------------------------
-void ofApp::exit() {
-	printf("exit()");
+void  ofApp::closeLoggers() {
 	for (auto it = loggers.cbegin(); it != loggers.cend(); ++it) {
+		ofLog(OF_LOG_VERBOSE, it->first
+			+ " push: " + ofToString(it->second->size(LoggerThread::LoggerQueue::PUSH))
+			+ ", pop: " + ofToString(it->second->size(LoggerThread::LoggerQueue::POP)));
+
+		it->second->stopThread();
+
+		ofLog(OF_LOG_VERBOSE, it->first
+			+ " push: " + ofToString(it->second->size(LoggerThread::LoggerQueue::PUSH))
+			+ ", pop: " + ofToString(it->second->size(LoggerThread::LoggerQueue::POP)));
 		delete it->second;
 	}
+
 	loggers.clear();
-	//recordingStatus.removeListener(this, &ofApp::recordButtonPressed);
+}
+
+//--------------------------------------------------------------
+void ofApp::exit() {
+	printf("exit()");
+	closeLoggers();
 }
 
 //--------------------------------------------------------------

--- a/EmotiBitDataParser/src/ofApp.cpp
+++ b/EmotiBitDataParser/src/ofApp.cpp
@@ -164,14 +164,6 @@ void ofApp::startProcessing(bool & processing) {
 
 //--------------------------------------------------------------
 void ofApp::update() {
-	// Give time clear the buffers if >1K lines of data in queue
-	//if (getMaxLoggerSize() > 1000) {
-	//	while (getMaxLoggerSize() > 0) {
-	//		ofSleepMillis(10);
-	//		cout << "*";
-	//	}
-	//}
-
 	if (currentState != State::WARNING_INSUFFICIENT_TIMESYNCS &&inFile.is_open()) {
 		int lines = 0;
 		while (lines < linesPerLoop) {
@@ -788,9 +780,15 @@ void  ofApp::closeLoggers() {
 		out += ", stopThread()";
 		it->second->stopThread();
 
+		size_t pushSize = it->second->size(LoggerThread::LoggerQueue::PUSH);
+		size_t popSize = it->second->size(LoggerThread::LoggerQueue::POP);
 		out += 
-			", push: " + ofToString(it->second->size(LoggerThread::LoggerQueue::PUSH))
-			+ ", pop: " + ofToString(it->second->size(LoggerThread::LoggerQueue::POP));
+			", push: " + ofToString(pushSize)
+			+ ", pop: " + ofToString(popSize);
+
+		if (pushSize > 0 || popSize > 0) {
+			ofLog(OF_LOG_ERROR, it->first + " buffer writes incomplete. Push Queue: " + ofToString(pushSize) + ", Pop Queue: " + ofToString(popSize) );
+		}
 
 		ofLog(OF_LOG_VERBOSE, out);
 		delete it->second;

--- a/EmotiBitDataParser/src/ofApp.h
+++ b/EmotiBitDataParser/src/ofApp.h
@@ -259,4 +259,8 @@ public:
 	double GetMedian(double daArray[], int iSize);
 	bool timestampDataCompare(pair<int, TimestampData> i, pair<int, TimestampData> j);
 	long double linterp(long double x, long double x0, long double x1, long double y0, long double y1);
+	/*!
+		@brief safely closes all the logger files after writing data
+	*/
+	void closeLoggers();
 };

--- a/EmotiBitDataParser/src/ofApp.h
+++ b/EmotiBitDataParser/src/ofApp.h
@@ -263,4 +263,10 @@ public:
 		@brief safely closes all the logger files after writing data
 	*/
 	void closeLoggers();
+
+	/*!
+		@brief returns the size of the largest logger
+		@return size of the largest logger
+	*/
+	size_t getMaxLoggerSize();
 };

--- a/EmotiBitOscilloscope/bin/data/emotibitCommSettings.json
+++ b/EmotiBitOscilloscope/bin/data/emotibitCommSettings.json
@@ -19,8 +19,8 @@
   },
   "lsl": {
     "marker": {
-      "name": "DA",
-      "sourceId": "12"
+      "name": "",
+      "sourceId": ""
     }
   }
 }

--- a/src/ofxEmotiBitVersion.h
+++ b/src/ofxEmotiBitVersion.h
@@ -2,7 +2,7 @@
 //#include <string>
 #include "ofMain.h"
 
-const std::string ofxEmotiBitVersion = "1.5.3.fix-partialParse.2";
+const std::string ofxEmotiBitVersion = "1.5.3.fix-partialParse.5";
 static const char SOFTWARE_VERSION_PREFIX = 'v';
 
 static void writeOfxEmotiBitVersionFile() {

--- a/src/ofxEmotiBitVersion.h
+++ b/src/ofxEmotiBitVersion.h
@@ -2,7 +2,7 @@
 //#include <string>
 #include "ofMain.h"
 
-const std::string ofxEmotiBitVersion = "1.5.2";
+const std::string ofxEmotiBitVersion = "1.5.3";
 static const char SOFTWARE_VERSION_PREFIX = 'v';
 
 static void writeOfxEmotiBitVersionFile() {

--- a/src/ofxEmotiBitVersion.h
+++ b/src/ofxEmotiBitVersion.h
@@ -2,7 +2,7 @@
 //#include <string>
 #include "ofMain.h"
 
-const std::string ofxEmotiBitVersion = "1.5.3";
+const std::string ofxEmotiBitVersion = "1.5.3.fix-partialParse.0";
 static const char SOFTWARE_VERSION_PREFIX = 'v';
 
 static void writeOfxEmotiBitVersionFile() {

--- a/src/ofxEmotiBitVersion.h
+++ b/src/ofxEmotiBitVersion.h
@@ -2,7 +2,7 @@
 //#include <string>
 #include "ofMain.h"
 
-const std::string ofxEmotiBitVersion = "1.5.3.fix-partialParse.5";
+const std::string ofxEmotiBitVersion = "1.5.3.fix-partialParse.6";
 static const char SOFTWARE_VERSION_PREFIX = 'v';
 
 static void writeOfxEmotiBitVersionFile() {

--- a/src/ofxEmotiBitVersion.h
+++ b/src/ofxEmotiBitVersion.h
@@ -2,7 +2,7 @@
 //#include <string>
 #include "ofMain.h"
 
-const std::string ofxEmotiBitVersion = "1.5.3.fix-partialParse.0";
+const std::string ofxEmotiBitVersion = "1.5.3.fix-partialParse.1";
 static const char SOFTWARE_VERSION_PREFIX = 'v';
 
 static void writeOfxEmotiBitVersionFile() {

--- a/src/ofxEmotiBitVersion.h
+++ b/src/ofxEmotiBitVersion.h
@@ -3,7 +3,7 @@
 #include "ofMain.h"
 
 
-const std::string ofxEmotiBitVersion = "1.5.3.fix-partialParse.7";
+const std::string ofxEmotiBitVersion = "1.5.5.fix-partialParse.7";
 static const char SOFTWARE_VERSION_PREFIX = 'v';
 
 static void writeOfxEmotiBitVersionFile() {

--- a/src/ofxEmotiBitVersion.h
+++ b/src/ofxEmotiBitVersion.h
@@ -2,7 +2,7 @@
 //#include <string>
 #include "ofMain.h"
 
-const std::string ofxEmotiBitVersion = "1.5.3.fix-partialParse.1";
+const std::string ofxEmotiBitVersion = "1.5.3.fix-partialParse.2";
 static const char SOFTWARE_VERSION_PREFIX = 'v';
 
 static void writeOfxEmotiBitVersionFile() {


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail -->
Fix to the parser, which ensures the complete raw file is parsed. The Parser now tracks the read and write thread to ensure enough time is given to the write threads to catch up with the read speeds.

# Requirements
- https://github.com/produceconsumerobot/ofxThreadedLogger/pull/1


# Issues Referenced
<!-- If Any -->
- Fixes #155 

# Documentation update
Link to a change in documentation (if any)


|Test | Result | Link |
|-----|--------|------|

# Checklist:

- [ ] doxygen style comments included
- [ ] Required documentation udpated

## Screenshots:
