### PR TITLE
Fix default json parsing

### DIFF
--- a/EmotiBitDataParser/src/ofApp.cpp
+++ b/EmotiBitDataParser/src/ofApp.cpp
@@ -265,18 +265,46 @@ void ofApp::ParsedDataFormat::loadFromFile(std::string filename, bool absolute)
 	try
 	{
 		// ToDo: find a place for these settings to be stored. a struct in ofApp?
-		jsonSettings.open(ofToDataPath(filename, absolute));
-		int numEntries = jsonSettings["timestampColumns"].size();
-		for (int i = 0; i < numEntries; i++)
+		ofFile parsedDataFormatFile(ofToDataPath(filename));
+		if (parsedDataFormatFile.exists())
 		{
-			if (jsonSettings["timestampColumns"][i]["addToOutput"].asBool())
+			if (jsonSettings.open(ofToDataPath(filename, absolute)))
 			{
-				std::string colHeader = jsonSettings["timestampColumns"][i]["columnHeader"].asString();
-				parsedDataHeaders.insert(parsedDataHeaders.begin(), colHeader);
-				additionalTimestamps.push_back(jsonSettings["timestampColumns"][i]["identifier"].asString());
+				if (jsonSettings.isMember("timestampColumns"))
+				{
+					int numEntries = jsonSettings["timestampColumns"].size();
+					for (int i = 0; i < numEntries; i++)
+					{
+						if (jsonSettings["timestampColumns"][i].isMember("addToOutput"))
+						{
+							if (jsonSettings["timestampColumns"][i]["addToOutput"].asBool())
+							{
+								std::string colHeader = jsonSettings["timestampColumns"][i]["columnHeader"].asString();
+								parsedDataHeaders.insert(parsedDataHeaders.begin(), colHeader);
+								additionalTimestamps.push_back(jsonSettings["timestampColumns"][i]["identifier"].asString());
+							}
+						}
+						else
+						{
+							ofLogNotice() << "addToOutput not found";
+						}
+					}
+					ofLog(OF_LOG_NOTICE, "Loaded " + filename + ": \n" + jsonSettings.getRawString(true));
+				}
+				else
+				{
+					ofLogNotice("Timestamp column list not found") << "Parsing with EmotiBit timestamps";
+				}
+			}
+			else
+			{
+				ofLogNotice() << "Parsing with only EmotiBit timestamps";
 			}
 		}
-		ofLog(OF_LOG_NOTICE, "Loaded " + filename + ": \n" + jsonSettings.getRawString(true));
+		else
+		{
+			ofLogNotice("File not found") << filename + ".Parsing with only EmotiBit timestamps";
+		}
 	}
 	catch (exception e)
 	{

--- a/EmotiBitDataParser/src/ofApp.cpp
+++ b/EmotiBitDataParser/src/ofApp.cpp
@@ -209,7 +209,7 @@ void ofApp::update() {
 					mFile << ofToString(timeSyncMap.anchorPoints[EmotiBitPacket::TypeTag::TIMESTAMP_EMOTIBIT].first, 6) << ","
 						<< ofToString(timeSyncMap.anchorPoints[EmotiBitPacket::TypeTag::TIMESTAMP_EMOTIBIT].second, 6) << ",";
 					// Add column headers for additional time domains read from parsed data format file
-					for (int i = 0;i <= parsedDataFormat.additionalTimestamps.size() - 1; i++)
+					for (int i = 0;i <= (int)parsedDataFormat.additionalTimestamps.size() - 1; i++)
 					{
 						auto timeDomain = parsedDataFormat.additionalTimestamps.at(i);
 						mFile << ofToString(timeSyncMap.anchorPoints[timeDomain].first, 6) << ","

--- a/EmotiBitOscilloscope/src/ofApp.cpp
+++ b/EmotiBitOscilloscope/src/ofApp.cpp
@@ -1706,7 +1706,7 @@ void ofApp::drawConsole()
 			if (!lslMarkerStreamInfo.srcId.empty())
 			{
 				updateStr += EmotiBitPacket::PAYLOAD_DELIMITER;
-				updateStr += (" " + JSON_SETTINGS_STRING_LSL_MARKER_INFO_SOOURCE_ID + ": ");
+				updateStr += (" " + JSON_SETTINGS_STRING_LSL_MARKER_INFO_SOURCE_ID + ": ");
 				updateStr += lslMarkerStreamInfo.srcId;
 			}
 			updateStr += ("): " + ofToString(consoleOutput.lslMarkerCount));
@@ -1720,7 +1720,7 @@ void ofApp::drawConsole()
 			if (!lslMarkerStreamInfo.srcId.empty())
 			{
 				updateStr += EmotiBitPacket::PAYLOAD_DELIMITER;
-				updateStr += (" " + JSON_SETTINGS_STRING_LSL_MARKER_INFO_SOOURCE_ID + ": ");
+				updateStr += (" " + JSON_SETTINGS_STRING_LSL_MARKER_INFO_SOURCE_ID + ": ");
 				updateStr += lslMarkerStreamInfo.srcId;
 			}
 			_consoleString += updateStr;
@@ -1869,36 +1869,104 @@ void ofApp::loadEmotiBitCommSettings(string settingsFilePath, bool absolute)
 	ofxJSONElement jsonSettings;
 	try
 	{
-		// ToDo find a nice home like EmotiBitFileIO.h/cpp
-		EmotiBitWiFiHost::HostAdvertisingSettings settings;
-		jsonSettings.open(ofToDataPath(settingsFilePath, absolute));
-
-		settings.enableBroadcast = jsonSettings["wifi"]["advertising"]["transmission"]["broadcast"]["enabled"].asBool();
-		settings.enableUnicast = jsonSettings["wifi"]["advertising"]["transmission"]["unicast"]["enabled"].asBool();
-		settings.unicastIpRange = make_pair(
-			jsonSettings["wifi"]["advertising"]["transmission"]["unicast"]["ipMin"].asInt(),
-			jsonSettings["wifi"]["advertising"]["transmission"]["unicast"]["ipMax"].asInt()
-		);
-
-		int numIncludes = jsonSettings["wifi"]["network"]["includeList"].size();
-		settings.networkIncludeList.clear();
-		for (int i = 0; i < numIncludes; i++)
+		ofFile commSettingsFile(ofToDataPath(settingsFilePath));
+		if (commSettingsFile.exists())
 		{
-			settings.networkIncludeList.push_back(jsonSettings["wifi"]["network"]["includeList"][i].asString());
-		}
+			// ToDo find a nice home like EmotiBitFileIO.h/cpp
+			EmotiBitWiFiHost::HostAdvertisingSettings settings;
+			EmotiBitWiFiHost::HostAdvertisingSettings defaultSettings = emotiBitWiFi.getHostAdvertisingSettings();// if setter is not called, getter returns default values
+			if (jsonSettings.open(ofToDataPath(settingsFilePath, absolute)))
+			{
+				if (jsonSettings["wifi"]["advertising"]["transmission"]["broadcast"].isMember("enabled"))
+				{
+					settings.enableBroadcast = jsonSettings["wifi"]["advertising"]["transmission"]["broadcast"]["enabled"].asBool();
+				}
+				else
+				{
+					ofLogNotice("Broadcast settings not found in ") <<  settingsFilePath + ".Using default value";
+					settings.enableBroadcast = defaultSettings.enableBroadcast;
+				}
+				if (jsonSettings["wifi"]["advertising"]["transmission"]["unicast"].isMember("enabled"))
+				{
+					settings.enableUnicast = jsonSettings["wifi"]["advertising"]["transmission"]["unicast"]["enabled"].asBool();
+				}
+				else
+				{
+					ofLogNotice("Unicast enable settings not found in ") << settingsFilePath + ". Using default value";
+					settings.enableUnicast = defaultSettings.enableUnicast;
+				}
+				if (jsonSettings["wifi"]["advertising"]["transmission"]["unicast"].isMember("ipMin") &&
+					jsonSettings["wifi"]["advertising"]["transmission"]["unicast"].isMember("ipMax"))
+				{
+					settings.unicastIpRange = make_pair(
+						jsonSettings["wifi"]["advertising"]["transmission"]["unicast"]["ipMin"].asInt(),
+						jsonSettings["wifi"]["advertising"]["transmission"]["unicast"]["ipMax"].asInt()
+					);
+				}
+				else
+				{
+					ofLogNotice("unicast ipRange settings not found in ") << settingsFilePath + ". Using default value";
+					settings.unicastIpRange = defaultSettings.unicastIpRange;
+				}
 
-		int numExcludes = jsonSettings["wifi"]["network"]["excludeList"].size();
-		settings.networkExcludeList.clear();
-		for (int i = 0; i < numIncludes; i++)
+				if (jsonSettings["wifi"]["network"].isMember("includeList"))
+				{
+					int numIncludes = jsonSettings["wifi"]["network"]["includeList"].size();
+					settings.networkIncludeList.clear();
+					for (int i = 0; i < numIncludes; i++)
+					{
+						settings.networkIncludeList.push_back(jsonSettings["wifi"]["network"]["includeList"][i].asString());
+					}
+				}
+				else
+				{
+					ofLogNotice("networkIncludeList settings not found in ") << settingsFilePath + ". Using default value";
+					settings.networkIncludeList = defaultSettings.networkIncludeList;
+				}
+
+				if (jsonSettings["wifi"]["network"].isMember("excludeList"))
+				{
+					int numExcludes = jsonSettings["wifi"]["network"]["excludeList"].size();
+					settings.networkExcludeList.clear();
+					for (int i = 0; i < numExcludes; i++)
+					{
+						settings.networkExcludeList.push_back(jsonSettings["wifi"]["network"]["excludeList"][i].asString());
+					}
+				}
+				else
+				{
+					ofLogNotice("networkExcludeList settings not found in ") << settingsFilePath + ". Using default value";
+					settings.networkExcludeList = defaultSettings.networkExcludeList;
+				}
+
+				emotiBitWiFi.setHostAdvertisingSettings(settings);
+				
+				if (jsonSettings.isMember("lsl"))
+				{
+					if (jsonSettings["lsl"].isMember("marker"))
+					{
+						if (jsonSettings["lsl"]["marker"].isMember(JSON_SETTINGS_STRING_LSL_MARKER_INFO_NAME))
+							lslMarkerStreamInfo.name = jsonSettings["lsl"]["marker"][JSON_SETTINGS_STRING_LSL_MARKER_INFO_NAME].asString();
+						if (jsonSettings["lsl"]["marker"].isMember(JSON_SETTINGS_STRING_LSL_MARKER_INFO_SOURCE_ID))
+							lslMarkerStreamInfo.srcId = jsonSettings["lsl"]["marker"][JSON_SETTINGS_STRING_LSL_MARKER_INFO_SOURCE_ID].asString();
+						// Note: We don't have to include an "else" here because LSL is a very special feature, and it is not required to 
+						// crowd the console with warnings about this feature.
+					}
+				}
+				ofLog(OF_LOG_NOTICE, "Loaded " + settingsFilePath + ": \n" + jsonSettings.getRawString(true));
+			}
+			else
+			{
+				ofLog(OF_LOG_NOTICE, "Using default network parameters");
+				emotiBitWiFi.setHostAdvertisingSettings(emotiBitWiFi.getHostAdvertisingSettings()); // if setter is not called, getter returns default values
+			}
+		}
+		else
 		{
-			settings.networkExcludeList.push_back(jsonSettings["wifi"]["network"]["excludeList"][i].asString());
+			ofLogError("File does not exist at") << settingsFilePath;
+			ofLog(OF_LOG_NOTICE, "using default network parameters");
+			emotiBitWiFi.setHostAdvertisingSettings(emotiBitWiFi.getHostAdvertisingSettings()); // if setter is not called, getter returns default values
 		}
-
-		emotiBitWiFi.setHostAdvertisingSettings(settings);
-		// ToDo: Add error handling for each section so that one section can fail, but the rest of the file can load properly and run.
-		lslMarkerStreamInfo.name = jsonSettings["lsl"]["marker"][JSON_SETTINGS_STRING_LSL_MARKER_INFO_NAME].asString();
-		lslMarkerStreamInfo.srcId = jsonSettings["lsl"]["marker"][JSON_SETTINGS_STRING_LSL_MARKER_INFO_SOOURCE_ID].asString();
-		ofLog(OF_LOG_NOTICE, "Loaded " + settingsFilePath + ": \n" + jsonSettings.getRawString(true));
 	}
 	catch (exception e)
 	{

--- a/EmotiBitOscilloscope/src/ofApp.h
+++ b/EmotiBitOscilloscope/src/ofApp.h
@@ -31,8 +31,8 @@ public:
 	*/
 	struct LslMarkerStreamInfo {
 		// For more info: https://github.com/sccn/liblsl/blob/5eded5c1d381a1a5fbbcce105edfaa53f009176a/include/lsl_cpp.h#L161
-		std::string name;  //!< marker stream inlet name for LSL
-		std::string srcId;  //!< marker stream inlet sourceId for LSL
+		std::string name = "";  //!< marker stream inlet name for LSL.
+		std::string srcId = "";  //!< marker stream inlet sourceId for LSL.
 	}lslMarkerStreamInfo;
 	void keyPressed(int key);
 	void keyReleased(int key);
@@ -232,7 +232,7 @@ public:
 	const string GUI_STRING_EMOTIBIT_SELECTED = "EmotiBit";
 	const string GUI_STRING_EMPTY_USER_NOTE = "[Add a note]";
 	const string JSON_SETTINGS_STRING_LSL_MARKER_INFO_NAME = "name";
-	const string JSON_SETTINGS_STRING_LSL_MARKER_INFO_SOOURCE_ID = "sourceId";
+	const string JSON_SETTINGS_STRING_LSL_MARKER_INFO_SOURCE_ID = "sourceId";
 	//const string GUI_POWER_STATUS_MENU_NAME = "RECORD";
 	const string GUI_POWER_MODE_GROUP_NAME = "Power Mode";
 	const string GUI_STRING_NORMAL_POWER =	 "Normal         (data streaming)";

--- a/src/ofxEmotiBitVersion.h
+++ b/src/ofxEmotiBitVersion.h
@@ -2,7 +2,7 @@
 //#include <string>
 #include "ofMain.h"
 
-const std::string ofxEmotiBitVersion = "1.5.4.feat-fix-defaultJsonParsing.0";
+const std::string ofxEmotiBitVersion = "1.5.4.feat-fix-defaultJsonParsing.1";
 static const char SOFTWARE_VERSION_PREFIX = 'v';
 
 static void writeOfxEmotiBitVersionFile() {

--- a/src/ofxEmotiBitVersion.h
+++ b/src/ofxEmotiBitVersion.h
@@ -2,7 +2,7 @@
 //#include <string>
 #include "ofMain.h"
 
-const std::string ofxEmotiBitVersion = "1.5.4.feat-fix-defaultJsonParsing.1";
+const std::string ofxEmotiBitVersion = "1.5.4.feat-fix-defaultJsonParsing.2";
 static const char SOFTWARE_VERSION_PREFIX = 'v';
 
 static void writeOfxEmotiBitVersionFile() {

--- a/src/ofxEmotiBitVersion.h
+++ b/src/ofxEmotiBitVersion.h
@@ -2,7 +2,7 @@
 //#include <string>
 #include "ofMain.h"
 
-const std::string ofxEmotiBitVersion = "1.5.4";
+const std::string ofxEmotiBitVersion = "1.5.4.feat-fix-defaultJsonParsing.0";
 static const char SOFTWARE_VERSION_PREFIX = 'v';
 
 static void writeOfxEmotiBitVersionFile() {


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail -->
Adds checks while parsing data stored in JSON setting files.
It now handles (for `emotibitCommSettings.json` and `parsedDataFormat`)
1. Partial contents
2. wrong file formatting
3. missing file

# Requirements
- None


# Issues Referenced
<!-- If Any -->
- Fixes #162 

# Documentation update
None

# Testing

**Test Configuration**:
* compiles on
  * ✔️ Windows
  * ✔️ macOS
  * ✔️ Linux

|Test | Result | Link |
|-----|--------|------|


# Checklist:

- [x] doxygen style comments included

## Screenshots:
Added to individual issue.