### PR TITLE
minor fix to change behavior of IP sweep in unicast

### DIFF
--- a/src/EmotiBitWiFiHost.cpp
+++ b/src/EmotiBitWiFiHost.cpp
@@ -238,12 +238,10 @@ void EmotiBitWiFiHost::sendAdvertising() {
 						unicastNetwork++;
 						if (unicastNetwork >= availableNetworks.size())
 						{
-							// finished a send of all IPs
-							sendInProgress = false;
+							// finished a send of all IPs. Start from beginning of available network list
 							unicastNetwork = 0;
 						}
 					}
-					break; // Finished a send of all IPs on a subnet. Break out of for.
 				}
 			}
 		}

--- a/src/EmotiBitWiFiHost.cpp
+++ b/src/EmotiBitWiFiHost.cpp
@@ -239,7 +239,9 @@ void EmotiBitWiFiHost::sendAdvertising() {
 						if (unicastNetwork >= availableNetworks.size())
 						{
 							// finished a send of all IPs. Start from beginning of available network list
+							sendInProgress = false;
 							unicastNetwork = 0;
+							break;
 						}
 					}
 				}

--- a/src/EmotiBitWiFiHost.cpp
+++ b/src/EmotiBitWiFiHost.cpp
@@ -232,13 +232,14 @@ void EmotiBitWiFiHost::sendAdvertising() {
 					{
 						// finished a send of all IPs
 						sendInProgress = false;
+						break;
 					}
 					else
 					{
 						unicastNetwork++;
 						if (unicastNetwork >= availableNetworks.size())
 						{
-							// finished a send of all IPs. Start from beginning of available network list
+							// reached end of unicastIpRange for the last known network in list
 							sendInProgress = false;
 							unicastNetwork = 0;
 							break;

--- a/src/ofxEmotiBitVersion.h
+++ b/src/ofxEmotiBitVersion.h
@@ -3,7 +3,7 @@
 #include "ofMain.h"
 
 
-const std::string ofxEmotiBitVersion = "1.7.1";
+const std::string ofxEmotiBitVersion = "1.7.2";
 
 static const char SOFTWARE_VERSION_PREFIX = 'v';
 


### PR DESCRIPTION
# Description
Minor fix to the protocol for IP sweep in unicast EmotiBit IP search.
Expected IP sweep
```
for a emotibitCommSettings.json file with contents
      "sendAdvertisingInterval_msec": 1000,
      "checkAdvertisingInterval_msec": 100,
      "transmission": {
        "broadcast": {
          "enabled": true
        },
        "unicast": {
          "enabled": true,
          "ipMax": 254,
          "ipMin": 250,
          "nUnicastIpsPerLoop": 3,
          "unicastMinLoopDelay_msec": 3
```
expected behavior is as shown below:
```
Ping begin
<send Broadcast>
<start unicast pinging>
ping 250
ping 251
ping 252
<wait 3 m secs>
ping 253
ping 254
<wait 1000m secs>
```
in case of multiple networks
```
Ping begin
<send Broadcast>
<start unicast pinging>
ping x.x.x.250
ping x.x.x.251
ping x.x.x.252
<wait 3m secs>
ping x.x.x.253
ping x.x.x.254
ping y.y.y.250
<wait 3m secs>
ping y.y.y.251
ping y.y.y.252
ping y.y.y.253
<wait 3m secs>
ping y.y.y.254
<wait 1000m secs>
```
# Requirements
- None


# Issues Referenced
- None

# Documentation update
- None

# Testing
- Tested working.

# Checklist to allow merge
- [x] All dependent repositories used were on branch `master`
- Software
  - [x] Passed testing on Windows
  - [ ] Passed testing on macOS
  - [ ] Passed testing on linux (ubuntu)
- Firmware
  - [ ] Set testingMode to TestingMode::NONE
  - [ ] Set const bool `DIGITAL_WRITE_DEBUG` = false (if set true while testing)
  - [ ] Update version in EmotiBit.h
  - [ ] Update library.properties to the correct version (should match EmotiBit.h)
- [x] Update software bundle version in `ofxEmotiBitVersion.h`
- [ ] doxygen style comments included for new code snippets
- [ ] Required documentation udpated

## Screenshots:
