### PR TITLE
fixed issue with temp plot resetting time scale

### DIFF
--- a/EmotiBitOscilloscope/src/ofApp.cpp
+++ b/EmotiBitOscilloscope/src/ofApp.cpp
@@ -251,9 +251,13 @@ void ofApp::setTypeTagPlotAttributes()
 
 void ofApp::resetScopePlot(int w, int s)
 {
+	// store the last set timeWindow before resetting
+	float lastTimeWindow = scopeWins.at(w).scopes.at(s).getTimeWindow();
 	scopeWins.at(w).scopes.at(s).clearData();
 	scopeWins.at(w).scopes.at(s).setup(timeWindowOnSetup, samplingFreqs.at(w).at(s), plotNames.at(w).at(s), plotColors.at(w).at(s),
 		0, 1);
+	// reset timeWindow to last set value
+	scopeWins.at(w).scopes.at(s).setTimeWindow(lastTimeWindow);
 }
 
 void ofApp::initMetaDataBuffers()

--- a/src/ofxEmotiBitVersion.h
+++ b/src/ofxEmotiBitVersion.h
@@ -3,7 +3,7 @@
 #include "ofMain.h"
 
 
-const std::string ofxEmotiBitVersion = "1.7.2";
+const std::string ofxEmotiBitVersion = "1.7.2.fix-tempPlotTimeScale.0";
 
 static const char SOFTWARE_VERSION_PREFIX = 'v';
 


### PR DESCRIPTION
# Description
- fixed issue with temp plot resetting time scale
  - Previously, the change made to plot time window by pressing arrow keys was lost when EmotiBit was disconnected.

# Requirements
- None


# Issues Referenced
<!-- If Any -->
- Fixes #182 

# Documentation update
- None

# Testing
## To Test
- Checkout the required branch and compile from source
- run the application and connect to an EmotiBit.
- Change the time window by pressing the arrow keys
- disconnect from EmotiBit
- Reconnect to EmotiBit/ connect to different EmotiBit
- Observe the timeWindow. It should be same as the value set before disconnect.

## Tests performed
**Test Configuration**:
* EmotiBit software version: `1.7.2.fix-tempPlotTimeScale.0`

|Input| Observation| Result |
|-----|--------|------|
| Disconnect/connect with same emotibit | timeWindow is maintained| ✔️  |
| Connect to different EmotiBit | timeWindow is maintained | ✔️ |
| Switch between EmotiBit MD/EM | timeWindow is maintained (even when plots go from 2 -> 1 | ✔️ |

# Checklist to allow merge
- [x] All dependent repositories used were on branch `master`
- Software
  - [x] Passed testing on Windows
  - [ ] Passed testing on macOS (very minor code change. not testing on macOS to avoid setup time cost)
  - [x] Passed testing on linux (ubuntu)
- Firmware
  - [ ] Set testingMode to TestingMode::NONE
  - [ ] Set const bool `DIGITAL_WRITE_DEBUG` = false (if set true while testing)
  - [ ] Update version in EmotiBit.h
  - [ ] Update library.properties to the correct version (should match EmotiBit.h)
- [ ] Update software bundle version in `ofxEmotiBitVersion.h`
- [ ] doxygen style comments included for new code snippets
- [ ] Required documentation udpated

## Screenshots:
