### PR TITLE
EmotiBit is identified by device Serial Number on Oscilloscope

### DIFF
--- a/EmotiBitOscilloscope/src/ofApp.cpp
+++ b/EmotiBitOscilloscope/src/ofApp.cpp
@@ -687,7 +687,6 @@ void ofApp::updateDeviceList()
 	for (auto it = discoveredEmotibits.begin(); it != discoveredEmotibits.end(); it++)
 	{
 		string deviceId = it->first;
-		string ip = it->second.ip;
 		bool available = it->second.isAvailable;
 		bool found = false;
 		// Search the GUI list to see if we're missing any EmotiBits
@@ -729,12 +728,11 @@ void ofApp::updateDeviceList()
 	{
 		// Update availability color
 		string deviceId = device->getName();
-		string ip = discoveredEmotibits[deviceId].ip;
 		bool available = false;
 		try { available = discoveredEmotibits.at(deviceId).isAvailable; }
 		catch (const std::out_of_range& oor) { oor; } // ignore exception
 		ofColor textColor;
-		if (available || ip.compare(emotiBitWiFi.connectedEmotibitIp) == 0)
+		if (available || deviceId.compare(emotiBitWiFi.connectedEmotibitIdentifier) == 0)
 		{
 			textColor = deviceAvailableColor;
 		}
@@ -746,14 +744,14 @@ void ofApp::updateDeviceList()
 
 		// Update device connection status checkbox
 		bool selected = device->get();
-		if (ip.compare(emotiBitWiFi.connectedEmotibitIp) == 0 && !selected)
+		if (deviceId.compare(emotiBitWiFi.connectedEmotibitIdentifier) == 0 && !selected)
 		{
 			// Connected to device -- checkbox needs to be checked
 			ofRemoveListener(deviceGroup.parameterChangedE(), this, &ofApp::deviceGroupSelection);
 			device->set(true);
 			ofAddListener(deviceGroup.parameterChangedE(), this, &ofApp::deviceGroupSelection);
 		}
-		else if (ip.compare(emotiBitWiFi.connectedEmotibitIp) != 0 && selected)
+		else if (deviceId.compare(emotiBitWiFi.connectedEmotibitIdentifier) != 0 && selected)
 		{
 			// Not connected to device -- checkbox needs to be unchecked
 			ofRemoveListener(deviceGroup.parameterChangedE(), this, &ofApp::deviceGroupSelection);
@@ -828,7 +826,6 @@ void ofApp::deviceGroupSelection(ofAbstractParameter& device)
 {
 	string deviceId = device.getName();
 	auto discoveredEmotibits = emotiBitWiFi.getdiscoveredEmotibits();
-	string ip = discoveredEmotibits[deviceId].ip;
 	bool selected = device.cast<bool>().get();
 	if (selected)
 	{
@@ -839,9 +836,9 @@ void ofApp::deviceGroupSelection(ofAbstractParameter& device)
 		if (available)
 		{
 			// Only respond to available selections
-			if (ip.compare(emotiBitWiFi.connectedEmotibitIp) == 0)
+			if (deviceId.compare(emotiBitWiFi.connectedEmotibitIdentifier) == 0)
 			{
-				// We're already connected to the selected IP, so enjoy a cold beer
+				// We're already connected to the selected device, so enjoy a cold beer
 			}
 			else
 			{
@@ -865,7 +862,7 @@ void ofApp::deviceGroupSelection(ofAbstractParameter& device)
 	else	
 	{
 		// device unselected
-		if (emotiBitWiFi.connectedEmotibitIp.compare(ip) == 0)
+		if (emotiBitWiFi.connectedEmotibitIdentifier.compare(deviceId) == 0)
 		{
 			// The device we're connected to has been unchecked... disconnect
 			emotiBitWiFi.disconnect();

--- a/EmotiBitOscilloscope/src/ofApp.h
+++ b/EmotiBitOscilloscope/src/ofApp.h
@@ -127,7 +127,6 @@ public:
 	ofTrueTypeFont subLegendFont;
 
 	EmotiBitWiFiHost emotiBitWiFi;
-	unordered_map<string, EmotiBitStatus> emotibitIps;
 	//struct EmotibitPacketHeader_V1 {
 	//	uint32_t timestamp;  // milliseconds since EmotiBit bootup
 	//	uint16_t packetCount;
@@ -191,7 +190,6 @@ public:
 	//ofParameter<string> deviceSelected;
 	ofxLabel deviceSelected;
 	vector<ofParameter<bool>> deviceList;
-	unordered_map<string, string> deviceIdToIp;
 	ofParameterGroup deviceGroup;
 	// ToDo: encapsulate sendData variables to be more portable/usable
 	vector<string> sendDataOptions;

--- a/EmotiBitOscilloscope/src/ofApp.h
+++ b/EmotiBitOscilloscope/src/ofApp.h
@@ -191,6 +191,7 @@ public:
 	//ofParameter<string> deviceSelected;
 	ofxLabel deviceSelected;
 	vector<ofParameter<bool>> deviceList;
+	unordered_map<string, string> deviceIdToIp;
 	ofParameterGroup deviceGroup;
 	// ToDo: encapsulate sendData variables to be more portable/usable
 	vector<string> sendDataOptions;

--- a/src/EmotiBitWiFiHost.h
+++ b/src/EmotiBitWiFiHost.h
@@ -121,7 +121,7 @@ public:
 	void processAdvertisingThread();
 	int8_t flushData();
 	//int8_t sendUdp(WiFiUDP& udp, const String& message, const IPAddress& ip, const uint16_t& port);
-	unordered_map<string, EmotibitInfo> getdiscoveredEmotibits();	// <IP address, availability to connect>
+	unordered_map<string, EmotibitInfo> getdiscoveredEmotibits();	// <device ID, device Information>
 	vector<string> getLocalIPs();
 	//string createPacket(string typeTag, string data = "", uint16_t dataLength = 0, uint8_t protocolVersion = 1, uint8_t dataReliability = 100);
 	//string createPacket(string typeTag, vector<string> data, uint8_t protocolVersion = 1, uint8_t dataReliability = 100);

--- a/src/EmotiBitWiFiHost.h
+++ b/src/EmotiBitWiFiHost.h
@@ -19,13 +19,15 @@
 
 using namespace EmotiBit;
 
-class EmotiBitStatus
+class EmotibitInfo
 {
 public:
-	EmotiBitStatus(bool isAvailable = false, uint64_t lastSeen = ofGetElapsedTimeMillis()) :
-		isAvailable(isAvailable), lastSeen(lastSeen) {}
+	EmotibitInfo(string ip = "", bool isAvailable = false, uint64_t lastSeen = ofGetElapsedTimeMillis()) :
+		ip(ip), isAvailable(isAvailable), lastSeen(lastSeen) {}
+	string ip;
 	bool isAvailable;
 	uint64_t lastSeen;
+	// Additional parameters like Name, Fs etc can be stored in this struct
 };
 
 class EmotiBitWiFiHost
@@ -73,8 +75,11 @@ public:
 	bool enableBroadcast = false; 
 	uint64_t advertizingTimer;
 
-	unordered_map<string, std::pair<string,EmotiBitStatus>> _emotibitIps;	// list of EmotiBit IP addresses
+	unordered_map<string, EmotibitInfo> _discoveredEmotibits;	// list of EmotiBit IP addresses
 	string connectedEmotibitIp;
+	// ToDo: Find a scalable solution to store connected EmotiBit details.
+	// Ex. If we want to change the selected emotibit name to be displayed, instead of ID
+	string connectedEmotibitIdentifier;  //!< stores the ID of the connected EmotiBit 
 	bool _isConnected;
 	bool isStartingConnection;
 	uint16_t startCxnTimeout = 5000;	// milliseconds
@@ -102,7 +107,7 @@ public:
 	void sendAdvertising();
 	void updateAdvertisingIpList(string ip); 
 	int8_t processAdvertising(vector<string> &infoPackets);
-	int8_t connect(string ip);
+	int8_t connect(string deviceId);
 	int8_t connect(uint8_t i);
 	int8_t disconnect();
 	int8_t sendControl(const string& packet);
@@ -116,7 +121,7 @@ public:
 	void processAdvertisingThread();
 	int8_t flushData();
 	//int8_t sendUdp(WiFiUDP& udp, const String& message, const IPAddress& ip, const uint16_t& port);
-	unordered_map<string, std::pair<string, EmotiBitStatus>> getEmotiBitIPs();	// <IP address, availability to connect>
+	unordered_map<string, EmotibitInfo> getdiscoveredEmotibits();	// <IP address, availability to connect>
 	vector<string> getLocalIPs();
 	//string createPacket(string typeTag, string data = "", uint16_t dataLength = 0, uint8_t protocolVersion = 1, uint8_t dataReliability = 100);
 	//string createPacket(string typeTag, vector<string> data, uint8_t protocolVersion = 1, uint8_t dataReliability = 100);

--- a/src/EmotiBitWiFiHost.h
+++ b/src/EmotiBitWiFiHost.h
@@ -73,7 +73,7 @@ public:
 	bool enableBroadcast = false; 
 	uint64_t advertizingTimer;
 
-	unordered_map<string, EmotiBitStatus> _emotibitIps;	// list of EmotiBit IP addresses
+	unordered_map<string, std::pair<string,EmotiBitStatus>> _emotibitIps;	// list of EmotiBit IP addresses
 	string connectedEmotibitIp;
 	bool _isConnected;
 	bool isStartingConnection;
@@ -116,7 +116,7 @@ public:
 	void processAdvertisingThread();
 	int8_t flushData();
 	//int8_t sendUdp(WiFiUDP& udp, const String& message, const IPAddress& ip, const uint16_t& port);
-	unordered_map<string, EmotiBitStatus> getEmotiBitIPs();	// <IP address, availability to connect>
+	unordered_map<string, std::pair<string, EmotiBitStatus>> getEmotiBitIPs();	// <IP address, availability to connect>
 	vector<string> getLocalIPs();
 	//string createPacket(string typeTag, string data = "", uint16_t dataLength = 0, uint8_t protocolVersion = 1, uint8_t dataReliability = 100);
 	//string createPacket(string typeTag, vector<string> data, uint8_t protocolVersion = 1, uint8_t dataReliability = 100);

--- a/src/ofxEmotiBitVersion.h
+++ b/src/ofxEmotiBitVersion.h
@@ -3,7 +3,7 @@
 #include "ofMain.h"
 
 
-const std::string ofxEmotiBitVersion = "1.7.3.feat-emotibitDeviceId.2";
+const std::string ofxEmotiBitVersion = "1.7.4";
 
 static const char SOFTWARE_VERSION_PREFIX = 'v';
 

--- a/src/ofxEmotiBitVersion.h
+++ b/src/ofxEmotiBitVersion.h
@@ -3,7 +3,7 @@
 #include "ofMain.h"
 
 
-const std::string ofxEmotiBitVersion = "1.7.3.feat-emotibitDeviceId.1";
+const std::string ofxEmotiBitVersion = "1.7.3.feat-emotibitDeviceId.2";
 
 static const char SOFTWARE_VERSION_PREFIX = 'v';
 

--- a/src/ofxEmotiBitVersion.h
+++ b/src/ofxEmotiBitVersion.h
@@ -3,7 +3,7 @@
 #include "ofMain.h"
 
 
-const std::string ofxEmotiBitVersion = "1.7.2.fix-tempPlotTimeScale.0";
+const std::string ofxEmotiBitVersion = "1.7.2.fix-tempPlotTimeScale.1";
 
 static const char SOFTWARE_VERSION_PREFIX = 'v';
 

--- a/src/ofxEmotiBitVersion.h
+++ b/src/ofxEmotiBitVersion.h
@@ -3,7 +3,7 @@
 #include "ofMain.h"
 
 
-const std::string ofxEmotiBitVersion = "1.7.3";
+const std::string ofxEmotiBitVersion = "1.7.3.feat-emotibitDeviceId.1";
 
 static const char SOFTWARE_VERSION_PREFIX = 'v';
 

--- a/src/ofxEmotiBitVersion.h
+++ b/src/ofxEmotiBitVersion.h
@@ -3,7 +3,7 @@
 #include "ofMain.h"
 
 
-const std::string ofxEmotiBitVersion = "1.7.2.fix-tempPlotTimeScale.1";
+const std::string ofxEmotiBitVersion = "1.7.2.fix-tempPlotTimeScale.0.feat-emotibitDeviceId.1";
 
 static const char SOFTWARE_VERSION_PREFIX = 'v';
 


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail -->
- The EmotiBits can now be identified by the EmotiBit serial number (unique to every emotibit) on the oscilloscope

# Requirements
- https://github.com/EmotiBit/EmotiBit_XPlat_Utils/pull/24

## Non-dependent requirements
To test the functionality, you will also need to flash the EmotiBit with the FW linked in the PR below.
- https://github.com/EmotiBit/EmotiBit_FeatherWing/pull/264

# Issues Referenced
<!-- If Any -->
- None

# Documentation update
- None

# Code change explained
- The flow of information is shown below
  - `EmotiBit` -> `EmotiBitWiFiHost (Oscilloscope)` -> `EmotiBit Oscilloscope (ofApp)` -> `GUI`
- Since the EmotiBit info data enters the Oscilloscope via WiFiHost, a new map has been created to store EmotiBit Info.
  - `unordered_map<string, EmotibitInfo> _discoveredEmotibits;`
- New EmotiBits when discovered are added to this data structure.
- If the EmotiBit transmits a device ID, then that is used as the "key". If no device ID is found, then the IP address is used as the key.
  - Example:
  - _discoveredEmotibits[192.168.1.100] = {`IP address`, `availability`, `lastSeen`} (for old firmware)
  - _discoveredEmotibits[MD-V5-0000100] = {`IP address`, `availability`, `lastSeen`} (for new firmware)
- This data structure also allows extensibility, as it can hold additional information about EmotiBits on network like name, Fs. FW version etc.
- The structure is updated periodically by the advertising channel (thread).
- The structure is then pulled by the `ofApp`, where the "key" is used to populate the deviceGroup list.


# Testing

**Test Configuration**:
* Firmware version:
* Hardware:
* EmotiBit software version

|Test | Result | Link |
|-----|--------|------|

# Checklist to allow merge
- [ ] All dependent repositories used were on branch `master`
- Software
  - [x] Passed testing on Windows
  - [ ] Passed testing on macOS
  - [ ] Passed testing on linux (ubuntu)
- Firmware
  - [ ] Set testingMode to TestingMode::NONE
  - [ ] Set const bool `DIGITAL_WRITE_DEBUG` = false (if set true while testing)
  - [ ] Update version in EmotiBit.h
  - [ ] Update library.properties to the correct version (should match EmotiBit.h)
- [ ] reset log_level
- [ ] Update software bundle version in `ofxEmotiBitVersion.h`
- [ ] doxygen style comments included for new code snippets
- [ ] Required documentation udpated

## Screenshots:
![image](https://user-images.githubusercontent.com/31810812/226500121-d0e30e92-d9b6-433e-bf47-0f51bbc82664.png)
