### PR TITLE
Updating esptool shipped with EmotiBit firmware installer

### DIFF
--- a/EmotiBitFirmwareInstaller/ReadMe.md
+++ b/EmotiBitFirmwareInstaller/ReadMe.md
@@ -1,2 +1,16 @@
 # EmotiBit Firmware Installer
 ToDo: Add details about implementation here.
+
+
+# Tools used to install firmware
+
+## Feather M0
+- bossac
+  - todo: add details about bossac
+## Feather ESP32
+
+- esptool
+  - EmotiBit Firmware Installer is currently using [`esptool v3.3`](https://github.com/espressif/esptool/releases/tag/v3.3) 
+to flash firmware binaries on ESP32 Feather
+  - Note for macOS
+    - After the esptool binary is obtained from the release page, it is made an executable by using the `chmod u+x` command.


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail -->
- The `esptool` currently being shipped with EmotiBit FirmwareInstaller for macos is breaking for later version of macos (big sur and above, specifically versions released after M1 macs)
- Here is a link to the error seen on the console
  - https://github.com/espressif/esptool/issues/540
  - Looks like it is a known issue that popped up with macOS big sur release.
- According to our [documentation](https://github.com/EmotiBit/EmotiBit_Docs/blob/master/Getting_Started.md#for-linux-and-advanced-users), we have been using [esptool `v3.3`](https://github.com/espressif/esptool/releases/tag/v3.3), but there are no developer notes specifying where the esptool binary was obtained from.
- The binary obtained form the esptool release page, is tested working with the following OS and hence is being shipped with the new firmware installer.
  - macOS mojave (Previous version of firmware installer was working without any issues)
  - macOS Big Sur
  - macOS Monterey
 
# Requirements
- None


# Issues Referenced
<!-- If Any -->
- Fixes #186

# Documentation update
None.

# Notes for Reviewer
- None

# Testing
## Results

|macOS version | Firmware Installer output | EmotiBit serial output | 
| --------------- | ----------------------------- | ----------------------- |
|macOS Mojave | ![Screen Shot 2023-04-20 at 4 34 23 PM](https://user-images.githubusercontent.com/31810812/233481998-557f13a4-636d-4632-a676-580bf0002765.png)| - |
|macOS Big Sur | ![Screen Shot 2023-04-20 at 4 16 02 PM](https://user-images.githubusercontent.com/31810812/233478447-c60e6e77-2148-4c13-bbb6-517652e24121.png)| <img width="365" alt="image" src="https://user-images.githubusercontent.com/31810812/233479140-53e9ece7-5800-46b9-a893-4c6184dc8a14.png">|
|macOS Monterey|![Screen Shot 2023-04-20 at 4 34 23 PM](https://user-images.githubusercontent.com/31810812/233481792-562f6389-8c64-45ed-811b-4d994b16b53c.png) |<img width="359" alt="image" src="https://user-images.githubusercontent.com/31810812/233482320-e1bc52fe-94f8-4b16-bc48-7d3d82d77ba1.png">|

## Unit Tests
- Firmware Installer uploads correct firmware

## Steps to test
- Run the firmware installer on the test machine.
- Verify the firmware is correctly installed using serial output.


## Screenshots:
