### PR TITLE
Feat parser sh re parse

### DIFF
--- a/EmotiBitDataParser/bin/EmotiBitDataParser.sh
+++ b/EmotiBitDataParser/bin/EmotiBitDataParser.sh
@@ -2,7 +2,7 @@
 
 exePath=$(pwd)
 dataDir=$(pwd)
-reRun=false
+reParse=false
 getHelp=false
 
 echo -e "";
@@ -15,7 +15,7 @@ do
     case "${flag}" in
         x) exePath=${OPTARG};;
         d) dataDir=${OPTARG};;
-        r) reRun=${OPTARG};;
+        r) reParse=${OPTARG};;
     esac
 done
 
@@ -25,7 +25,7 @@ dataDir="${dataDir//\\//}"
 
 echo "[-x] exePath: $exePath";
 echo "[-d] dataDir: $dataDir";
-echo "[-r] reRun: $reRun";
+echo "[-r] reParse: $reParse";
 
 currDir=$(pwd);
 echo -e "\npwd: $currDir"
@@ -33,7 +33,7 @@ echo -e "\npwd: $currDir"
 cd "$dataDir"
 
 files="";
-if $reRun
+if $reParse
 then
   # Process through [dirName]/[dirName].csv
   files=$(eval "ls -d */")
@@ -46,7 +46,7 @@ for file in $files
 do
 	echo -e "\nprocessing: $file"
 	subDirName=$(basename $file .csv)
-  if ! $reRun
+  if ! $reParse
   then
     echo "mkdir: $subDirName"
     mkdir $subDirName

--- a/EmotiBitDataParser/bin/EmotiBitDataParser.sh
+++ b/EmotiBitDataParser/bin/EmotiBitDataParser.sh
@@ -35,8 +35,10 @@ cd "$dataDir"
 files="";
 if $reRun
 then
+  # Process through [dirName]/[dirName].csv
   files=$(eval "ls -d */")
 else
+  # Process through all ./*.csv 
   files=$(eval "ls *.csv")
 fi
 

--- a/EmotiBitDataParser/bin/EmotiBitDataParser.sh
+++ b/EmotiBitDataParser/bin/EmotiBitDataParser.sh
@@ -2,6 +2,7 @@
 
 exePath=$(pwd)
 dataDir=$(pwd)
+reRun=false
 getHelp=false
 
 echo -e "";
@@ -9,11 +10,12 @@ echo -e "** EmotiBitDataParser.sh ** ";
 echo -e "Runs EmotiBitDataParser on *.csv in passed data directory\n";
 echo -e 'Example input:\n./EmotiBitDataParser.sh -x "C:\\Program Files\\EmotiBit\\EmotiBit DataParser\\EmotiBitDataParser.exe" -d "C:\\priv\\local\\EmotiBitData\\"\n'
 
-while getopts x:d: flag
+while getopts x:d:r: flag
 do
     case "${flag}" in
         x) exePath=${OPTARG};;
         d) dataDir=${OPTARG};;
+        r) reRun=${OPTARG};;
     esac
 done
 
@@ -23,20 +25,32 @@ dataDir="${dataDir//\\//}"
 
 echo "[-x] exePath: $exePath";
 echo "[-d] dataDir: $dataDir";
+echo "[-r] reRun: $reRun";
 
 currDir=$(pwd);
 echo -e "\npwd: $currDir"
 
 cd "$dataDir"
 
-for file in $(eval "ls *.csv")
+files="";
+if $reRun
+then
+  files=$(eval "ls -d */")
+else
+  files=$(eval "ls *.csv")
+fi
+
+for file in $files
 do
 	echo -e "\nprocessing: $file"
 	subDirName=$(basename $file .csv)
-	echo "mkdir: $subDirName"
-	mkdir $subDirName
-  mv $file $subDirName
-	mv "$subDirName"_info.json $subDirName
+  if ! $reRun
+  then
+    echo "mkdir: $subDirName"
+    mkdir $subDirName
+    mv $file $subDirName
+    mv "$subDirName"_info.json $subDirName
+  fi
 	cd "$currDir" #cd to currDir before cmd Prevents ofDirectory errors
 	cmd="\"$exePath\" \"$dataDir/$subDirName/$subDirName.csv\""
 	echo "cmd: $cmd"


### PR DESCRIPTION
# Description
Added feature to reParse data to EmotiBitDataParser.sh

# Usage
- Pass the argument `-r true` in the shell command
- Example:
Original directory structure
```
-- user1 (root folder)
|-- 2023-04-16_11-47-34-166828.csv
|-- 2023-04-16_11-47-48-309342.csv
|-- 2023-04-16_15-53-49-307046.csv
|-- 2023-04-16_16-21-18-728199.csv
```
After running parser script for the first time, each individual file is moved to a new sub-directory. The parsed data is stored in the same sub directory.
```
-- user1 (root folder)
|-- 2023-04-16_11-47-34-166828
|---|-- 2023-04-16_11-47-34-166828.csv + Parsed files
|-- 2023-04-16_11-47-48-309342
|---|-- 2023-04-16_11-47-48-309342.csv  + Parsed files
|-- 2023-04-16_15-53-49-307046
|---|-- 2023-04-16_15-53-49-307046.csv + Parsed files
|-- 2023-04-16_16-21-18-728199
|---|-- 2023-04-16_16-21-18-728199.csv + Parsed files
```
If you want to rerun the parser (maybe with new settings in the `parsedDataFormat.json` file), then simple run the command
`./EmotiBitDataParser.sh -x "path to parser exe" -d "path to root folder" -r true`
It will delete the existing parsed files from the sub-directory and re-parse the original data file.

**Note: The reparse will only work for sub-directories in the root folder which contain the csv file with the same same as the sub-directory.**
```
-- user1 (root folder)
|-- 2023-04-16_11-47-34-166828 (will be reparsed)
|---|-- 2023-04-16_11-47-34-166828.csv + Parsed files
|-- 2023-04-16_11-47-48-309342  (will be reparsed)
|---|-- 2023-04-16_11-47-48-309342.csv  + Parsed files
|-- 2023-04-16_15-53-49-307046 (will be reparsed)
|---|-- 2023-04-16_15-53-49-307046.csv + Parsed files
|-- some-other-folder (will be skipped in reparse)
|---|-- contents
```

# Requirements
- None


# Issues Referenced
<!-- If Any -->
- None

# Documentation update
Link to a change in documentation (if any)



# Testing
<!--- The testing results should be added to the main PR behind this bug-fix/ feature-add -->

## Results
<!--- The main results should be recorded in the appropriate testing results sheet -->
- Tested working on windows dev machine.

## Feature Tests
<!--- For each test case, create a unit test in the `EmotiBit Feature Test Protocol` document. -->
<!--- For firmware, the corresponding results recorded in the `EmotiBit Feature Testing Results` sheet. -->
<!--- For software, the corresponding results are recorded in the `EmotiBit Software Testing Records` sheet. -->
"EmotiBit Feature Test Protocol" : `DataParser shell script reParse`

## Steps to test
- Parse data file using the parser script (without reParse option)
  - Observe: The original file will be moved to a sub-directory with the same name. The parsed files will be stored in the same sub-directory
- Parse the data again, with the same command in the previous step, with the addition of the reParse flag. Notice that the -d argument remains the same, even though the original data file has now moved to a new sub-directory
  - Observe: The original parsed files will be deleted and replaced with the ned parsed files


# Checklist to allow merge
- [x] All dependent repositories used were on branch `master`
- Software
  - [x] Get approval from the reviewer
  - [x] Passed testing on Windows
  - [skipped] Passed testing on macOS *(for major changes/GUI changes/ PRs adding files distributed with the EmotiBit software)*
  - [skipped] Passed testing on linux (ubuntu) *(for major changes/GUI changes/ PRs adding files distributed with the EmotiBit software)*
  - [skipped] Update software bundle version in `ofxEmotiBitVersion.h`

## Screenshots: