### PR TITLE
Fix to be compatible with OF v0.11.2

### DIFF
--- a/EmotiBitDataParser/EmotiBitDataParser.xcodeproj/project.pbxproj
+++ b/EmotiBitDataParser/EmotiBitDataParser.xcodeproj/project.pbxproj
@@ -1268,7 +1268,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "mkdir -p \"$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/Resources/\"\n# Copy default icon file into App/Resources\nrsync -aved \"$ICON_FILE\" \"$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/Resources/\"\n# Copy libfmod and change install directory for fmod to run\nrsync -aved \"$OF_PATH/libs/fmodex/lib/osx/libfmodex.dylib\" \"$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/Frameworks/\";\ninstall_name_tool -change @executable_path/libfmodex.dylib @executable_path/../Frameworks/libfmodex.dylib \"$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/MacOS/$PRODUCT_NAME\";\n\necho \"$GCC_PREPROCESSOR_DEFINITIONS\";\n";
+			shellScript = "mkdir -p \"$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/Resources/\"\n# Copy default icon file into App/Resources\nrsync -aved \"$ICON_FILE\" \"$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/Resources/\"\n# Copy libfmod and change install directory for fmod to run\nrsync -aved \"$OF_PATH/libs/fmod/lib/osx/libfmod.dylib\" \"$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/Frameworks/\";\ninstall_name_tool -change @executable_path/libfmodex.dylib @executable_path/../Frameworks/libfmod.dylib \"$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/MacOS/$PRODUCT_NAME\";\n\necho \"$GCC_PREPROCESSOR_DEFINITIONS\";\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/EmotiBitDataParser/src/ofApp.cpp
+++ b/EmotiBitDataParser/src/ofApp.cpp
@@ -24,7 +24,7 @@ void ofApp::setup() {
 	int guiYPos = 20;
 	int guiWidth = ofGetWindowWidth();
 	int guiPosInc = guiWidth + 1;
-	guiPanels.resize(1);
+	//guiPanels.resize(1); // This fails in OF v0.11.2 with "attempting to reference a deleted function" error
 	guiPanels.at(0).setDefaultWidth(guiWidth);
 	guiPanels.at(0).setup("startRecording","junk.xml", guiXPos, -guiYPos);
 	guiPanels.at(0).add(processStatus.setup("Status", GUI_STATUS_IDLE));

--- a/EmotiBitDataParser/src/ofApp.h
+++ b/EmotiBitDataParser/src/ofApp.h
@@ -55,7 +55,7 @@ public:
 	//ofxButton ringButton;
 	//ofxLabel screenSize;
 
-  vector<ofxPanel> guiPanels;
+  vector<ofxPanel> guiPanels = vector<ofxPanel>(1); // OF v0.11.2 requires vector initialization to avoid "attempting to reference a deleted function" error
 
 	unordered_map<string, uint32_t> timestamps;
 	unordered_map<string, LoggerThread*> loggers;

--- a/EmotiBitFirmwareInstaller/EmotiBitFirmwareInstaller.xcodeproj/project.pbxproj
+++ b/EmotiBitFirmwareInstaller/EmotiBitFirmwareInstaller.xcodeproj/project.pbxproj
@@ -1939,7 +1939,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "mkdir -p \"$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/Resources/\"\n# Copy default icon file into App/Resources\nrsync -aved \"$ICON_FILE\" \"$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/Resources/\"\n# Copy libfmod and change install directory for fmod to run\nrsync -aved \"$OF_PATH/libs/fmodex/lib/osx/libfmodex.dylib\" \"$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/Frameworks/\";\ninstall_name_tool -change @executable_path/libfmodex.dylib @executable_path/../Frameworks/libfmodex.dylib \"$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/MacOS/$PRODUCT_NAME\";\n\necho \"$GCC_PREPROCESSOR_DEFINITIONS\";\n";
+			shellScript = "mkdir -p \"$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/Resources/\"\n# Copy default icon file into App/Resources\nrsync -aved \"$ICON_FILE\" \"$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/Resources/\"\n# Copy libfmod and change install directory for fmod to run\nrsync -aved \"$OF_PATH/libs/fmod/lib/osx/libfmod.dylib\" \"$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/Frameworks/\";\ninstall_name_tool -change @executable_path/libfmod.dylib @executable_path/../Frameworks/libfmodex.dylib \"$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/MacOS/$PRODUCT_NAME\";\n\necho \"$GCC_PREPROCESSOR_DEFINITIONS\";\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/EmotiBitOscilloscope/EmotiBitOscilloscope.xcodeproj/project.pbxproj
+++ b/EmotiBitOscilloscope/EmotiBitOscilloscope.xcodeproj/project.pbxproj
@@ -1556,7 +1556,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "mkdir -p \"$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/Resources/\"\n# Copy default icon file into App/Resources\nrsync -aved \"$ICON_FILE\" \"$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/Resources/\"\n# Copy libfmod and change install directory for fmod to run\nrsync -aved \"$OF_PATH/libs/fmodex/lib/osx/libfmodex.dylib\" \"$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/Frameworks/\";\ninstall_name_tool -change @executable_path/libfmodex.dylib @executable_path/../Frameworks/libfmodex.dylib \"$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/MacOS/$PRODUCT_NAME\";\n\necho \"$GCC_PREPROCESSOR_DEFINITIONS\";\n";
+			shellScript = "mkdir -p \"$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/Resources/\"\n# Copy default icon file into App/Resources\nrsync -aved \"$ICON_FILE\" \"$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/Resources/\"\n# Copy libfmod and change install directory for fmod to run\nrsync -aved \"$OF_PATH/libs/fmod/lib/osx/libfmod.dylib\" \"$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/Frameworks/\";\ninstall_name_tool -change @executable_path/libfmod.dylib @executable_path/../Frameworks/libfmod.dylib \"$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/MacOS/$PRODUCT_NAME\";\n\necho \"$GCC_PREPROCESSOR_DEFINITIONS\";\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/EmotiBitOscilloscope/src/ofApp.cpp
+++ b/EmotiBitOscilloscope/src/ofApp.cpp
@@ -1250,7 +1250,7 @@ void ofApp::setupGui()
 	int guiWidth = 220;
 	int guiPosInc = guiWidth + 1;
 	
-	guiPanels.resize(6);
+	//guiPanels.resize(6); // This fails in OF v0.11.2 with "attempting to reference a deleted function" error
 
 	// Device Menu
 	int p = 0;

--- a/EmotiBitOscilloscope/src/ofApp.h
+++ b/EmotiBitOscilloscope/src/ofApp.h
@@ -265,7 +265,7 @@ public:
 	//ofxButton ringButton;
 	//ofxLabel screenSize;
 
-  vector<ofxPanel> guiPanels;
+	vector<ofxPanel> guiPanels = vector<ofxPanel>(6); // OF v0.11.2 requires vector initialization to avoid "attempting to reference a deleted function" error
 
 	bool plotUdpData = true;
 	bool DEBUGGING = false;

--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ If you want to modify the code(or build the tools in Linux), below are the requi
 - **Adding paths to Library search paths**
   - Check if the directory paths for the files `liblsl64-static.a` and `liblslboost.a` are already present in the `project` > `Build Settings` > `Library Search Paths`. If they are not present, follow the below steps:  
     - Select your project in the **Target group**(in xcode project navigator), go to **Build Settings** tab, and add the following path in the **Library Search Paths** section: `../../../addons/ofxLSL/libs/labstreaminglayer/lib/osx`
+- For `EmotiBitDataParser`, if you get an error `ERROR: -NSDocumentRevisionsDebugMode does not exist, try absolute path` when compiling in `debug mode`,
+  - Choose the `build scheme` on the top left
+  - In the `Run` tab, open the `Options` tab
+  - unckeck the `Allow debugging when using document Version Browser` checkbox
+  - Try building again.
 
 ## Developing on Linux
 - You will require a version of gcc on your linux machine. Depending on the version, we need to install the appropriate OpenFrameworks code base. You can check the gcc verison on you system using the following command: `gcc --verison`.


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail -->

# Requirements
See standard dependencies: https://github.com/EmotiBit/ofxEmotiBit/blob/master/README.md#the-following-script-may-be-run-from-a-bash-shell-within-your-openframeworksaddons-directory-to-install-ofxemotibit-and-all-dependencies

# Issues Referenced
- fixes #216 

# Documentation update
none

# Notes for Reviewer
- Needed to initialize vector<ofxPanel> guiPanels to avoid unique_ptr double delete error

# Testing
<!--- The testing results should be added to the main PR behind this bug-fix/ feature-add -->
<!--- If another **linked PR** is the main PR for this bug-fix/ feature-add, you may then remove this testing section and add a link to the main PR here with the explicit statement "testing results added to PR(link)". -->
- ✅ EmotiBitOscilloscope runs on windows
- ✅ EmotiBitDataParser runs on windows
- ✅ EmotiBitFirmwareInstaller still runs on windows (worked without mod on OF v0.11.2)
- ✅ EmotiBitOscilloscope runs on mac (intel mac, Mojave)
- ✅ EmotiBitDataParser runs on mac (intel mac, Mojave)
- ✅ EmotiBitFirmwareInstaller still runs on mac (intel mac, Mojave)
- ✅  EmotiBitOscilloscope runs on linux
- ✅  EmotiBitDataParser runs on linux
- ✅  EmotiBitFirmwareInstaller still runs on linux

## Feature Tests
<!--- For each test case, create a unit test in the `EmotiBit Feature Test Protocol` document. -->
<!--- For firmware, the corresponding results recorded in the `EmotiBit Feature Testing Results` sheet. -->
<!--- For software, the corresponding results are recorded in the `EmotiBit Software Testing Records` sheet. -->
<!--- Add the test heading from "EmotiBit Feature Test Protocol" here. -->
Non

## Steps to test
<!--- Import the steps from the `EmotiBit Feature Test Protocol` for quick access for the reviewer -->
Build & run

# Shared files
None

# Checklist to allow merge
- [ ] All dependent repositories used were on branch `master`
- Software
  - [ ] Get approval from the reviewer
  - [ ] Passed testing on Windows
  - [ ] Passed testing on macOS *(for major changes/GUI changes/ PRs adding files distributed with the EmotiBit software)*
  - [ ] Passed testing on linux (ubuntu) *(for major changes/GUI changes/ PRs adding files distributed with the EmotiBit software)*
  - [ ] Update software bundle version in `ofxEmotiBitVersion.h`
- Firmware
  - [ ] Set testingMode to TestingMode::NONE
  - [ ] Set [const bool `DIGITAL_WRITE_DEBUG`](https://github.com/EmotiBit/EmotiBit_FeatherWing/blob/e2ed2dcb70c57c33f70e3a131f82c16627b519df/EmotiBit.h#L58) = false (if set true while testing)
  - [ ] Update version in EmotiBit.h
  - [ ] Update library.properties to the correct version (should match EmotiBit.h)
- [ ] doxygen style comments included for new code snippets
- [ ] Required documentation updated


## Screenshots:
