### PR TITLE
fixes to enabled compile on linux

### DIFF
--- a/EmotiBitOscilloscope/config.make
+++ b/EmotiBitOscilloscope/config.make
@@ -37,7 +37,7 @@
 #
 #   Note: Leave a leading space when adding list items with the += operator
 ################################################################################
-# PROJECT_EXTERNAL_SOURCE_PATHS = 
+PROJECT_EXTERNAL_SOURCE_PATHS=$(PROJECT_ROOT)/../../ofxOscilloscope/ofxPatchboard/Patchboard/src
 
 ################################################################################
 # PROJECT EXCLUSIONS

--- a/src/EmotiBitOfUtils.h
+++ b/src/EmotiBitOfUtils.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "ofmain.h"
+#include "ofMain.h"
 
 namespace EmotiBit
 {


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail -->

# Requirements
- [PR #(Link PR)](https://github.com/produceconsumerobot/ofxOscilloscope/pull/6)
  - required a separate makefile for the ofxOscilloscope addon because ofxPatchboard was not in the stardard `include` or `src` directories that the makefile in openframeworks is set to. 


# Issues Referenced
<!-- If Any -->
- None

# Documentation update
- None

# Notes for Reviewer
- Add detailed notes explaining code changes, algorithms or any other information that can help the reviewer understand the PR better.

# List of new distributable files (For software PR only)
- Name all new files added with this PR that need to be distributed with the release package. This includes files like `.json`, `.xml` settings files etc.

# Testing
<!--- The testing results should be added to the main PR behind this bug-fix/ feature-add -->
<!--- If another **linked PR** is the main PR for this bug-fix/ feature-add, you may then remove this testing section and add a link to the main PR here with the explicit statement "testing results added to PR(link)". -->

## Results
<!--- The main results should be recorded in the appropriate testing results sheet -->
- Tested building on windows, macos and linux
