### PR TITLE
Fix parser tests

### DIFF
--- a/tests/EmotiBitDataParser/check_parsed_data/expected_output_hash/2025-06-27_09-56-59-929206_timeSyncMap.md5
+++ b/tests/EmotiBitDataParser/check_parsed_data/expected_output_hash/2025-06-27_09-56-59-929206_timeSyncMap.md5
@@ -1,1 +1,0 @@
-1c59e746cbcf54c05fc0e2857feffc29  ../sample_data/2025-06-27_09-56-59-929206_timeSyncMap.csv

--- a/tests/EmotiBitDataParser/parsed_output_format/expected_output_hash/2025-06-27_09-56-59-929206_timeSyncMap.md5
+++ b/tests/EmotiBitDataParser/parsed_output_format/expected_output_hash/2025-06-27_09-56-59-929206_timeSyncMap.md5
@@ -1,1 +1,0 @@
-3489e0fe0fbc6691c0b811a2487371c2  ../sample_data/2025-06-27_09-56-59-929206_timeSyncMap.csv


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail -->
- removes data parser test for _timeSyncMap. This file contains the version number, therefore it can change with every new update to data parser
- We need to find a new test to test for timeSyncMap file

