### PR TITLE
added a patch to backup settings files in Windows Firmware Installer

### DIFF
--- a/src/ofxEmotiBitVersion.h
+++ b/src/ofxEmotiBitVersion.h
@@ -3,7 +3,7 @@
 #include "ofMain.h"
 
 
-const std::string ofxEmotiBitVersion = "1.14.4";
+const std::string ofxEmotiBitVersion = "1.14.5";
 
 static const char SOFTWARE_VERSION_PREFIX = 'v';
 


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail -->
- current strategy
  - We currently copy all existing settings files with a modified name [original name]_backup_[timestamp]
  - We then copy all settings files with the new app version
  - For each new settings file, we perform a “equality” check with the backed up file. If the new file is the   same as the backup, we delete the backup
  - If the files are not equal, we keep the backup
- See `Handling settings file updates in EmotiBit applications` in drive for notes.

# Requirements
<!--- This sections defines on a high level what the reviewer might need to test/conduct a review. This can include other PRs, toolchains, softwares, files etc. -->
<!--- For example, Requirements can be a specific branch of another repository that is a dependency. -->
<!--- Another example can be downloading tools like VS or anaconda -->
- None


# Issues Referenced
<!-- Prefix issue number with keyword "Fixes" to automatically close issue on PR merge.-->
<!-- FOr example, Fixes #34-->
- Fixes # (issue)

# Documentation update
- None



# Testing
<!--- The testing results should be added to the main PR behind this bug-fix/ feature-add -->
<!--- If another **linked PR** is the main PR for this bug-fix/ feature-add, you may then remove this testing section and add a link to the main PR here with the explicit statement "testing results added to PR(link)". -->
- tested to backup modified files
- tested the backup path
- tested uninstall removes all files
- tested auto uninstall v1.12.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings are backed up before install/upgrade, with identical backups auto-removed and a post-install notification if custom settings remain.
  * Installer preserves user settings across MSI-based upgrades and includes app fonts during install.
  * Uninstall now removes app folders and cleans up parent directory when empty.

* **Chores**
  * Version bumped to 1.14.5.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->