### PR TITLE
Fix/deps namespace issues

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -1,13 +1,49 @@
 {
   "dependencies": [
-    { "name": "ofxNetworkUtils",      "repo": "https://github.com/bakercp/ofxNetworkUtils.git",               "ref": "stable"  },
-    { "name": "ofxOscilloscope",      "repo": "https://github.com/produceconsumerobot/ofxOscilloscope.git",   "ref": "master"  },
-    { "name": "ofxThreadedLogger",    "repo": "https://github.com/produceconsumerobot/ofxThreadedLogger.git", "ref": "master"  },
-    { "name": "ofxBiquadFilter",      "repo": "https://github.com/smukkejohan/ofxBiquadFilter.git",           "ref": "master"  },
-    { "name": "ofxJSON",              "repo": "https://github.com/jeffcrouse/ofxJSON.git",                    "ref": "master"  },
-    { "name": "EmotiBit_XPlat_Utils", "repo": "https://github.com/EmotiBit/EmotiBit_XPlat_Utils.git",        "ref": "master"  },
-    { "name": "ofxLSL",               "repo": "https://github.com/EmotiBit/ofxLSL.git",                      "ref": "master"  },
-    { "name": "ofxSerial",            "repo": "https://github.com/EmotiBit/ofxSerial.git",                   "ref": "stable"  },
-    { "name": "ofxIO",                "repo": "https://github.com/bakercp/ofxIO.git",                        "ref": "stable"  }
+    {
+      "name": "ofxNetworkUtils",
+      "repo": "https://github.com/bakercp/ofxNetworkUtils.git",
+      "ref": "stable"
+    },
+    {
+      "name": "ofxOscilloscope",
+      "repo": "https://github.com/produceconsumerobot/ofxOscilloscope.git",
+      "ref": "fix/namespace_issues"
+    },
+    {
+      "name": "ofxThreadedLogger",
+      "repo": "https://github.com/produceconsumerobot/ofxThreadedLogger.git",
+      "ref": "fix/namespace_issues"
+    },
+    {
+      "name": "ofxBiquadFilter",
+      "repo": "https://github.com/smukkejohan/ofxBiquadFilter.git",
+      "ref": "master"
+    },
+    {
+      "name": "ofxJSON",
+      "repo": "https://github.com/jeffcrouse/ofxJSON.git",
+      "ref": "master"
+    },
+    {
+      "name": "EmotiBit_XPlat_Utils",
+      "repo": "https://github.com/EmotiBit/EmotiBit_XPlat_Utils.git",
+      "ref": "master"
+    },
+    {
+      "name": "ofxLSL",
+      "repo": "https://github.com/EmotiBit/ofxLSL.git",
+      "ref": "fix/namespace_issues"
+    },
+    {
+      "name": "ofxSerial",
+      "repo": "https://github.com/EmotiBit/ofxSerial.git",
+      "ref": "stable"
+    },
+    {
+      "name": "ofxIO",
+      "repo": "https://github.com/bakercp/ofxIO.git",
+      "ref": "stable"
+    }
   ]
 }

--- a/dependencies.json
+++ b/dependencies.json
@@ -8,12 +8,12 @@
     {
       "name": "ofxOscilloscope",
       "repo": "https://github.com/produceconsumerobot/ofxOscilloscope.git",
-      "ref": "fix/namespace_issues"
+      "ref": "master"
     },
     {
       "name": "ofxThreadedLogger",
       "repo": "https://github.com/produceconsumerobot/ofxThreadedLogger.git",
-      "ref": "fix/namespace_issues"
+      "ref": "master"
     },
     {
       "name": "ofxBiquadFilter",
@@ -33,7 +33,7 @@
     {
       "name": "ofxLSL",
       "repo": "https://github.com/EmotiBit/ofxLSL.git",
-      "ref": "fix/namespace_issues"
+      "ref": "master"
     },
     {
       "name": "ofxSerial",

--- a/src/ofxEmotiBitVersion.h
+++ b/src/ofxEmotiBitVersion.h
@@ -2,7 +2,7 @@
 //#include <string>
 #include "ofMain.h"
 
-const std::string ofxEmotiBitVersion = "1.16.1";
+const std::string ofxEmotiBitVersion = "1.16.2";
 
 static const char SOFTWARE_VERSION_PREFIX = 'v';
 


### PR DESCRIPTION
# Description
- The following dependencies had a minor change, relating to the namespace
  - https://github.com/produceconsumerobot/ofxThreadedLogger/pull/2 
  - https://github.com/produceconsumerobot/ofxOscilloscope/pull/8
  - https://github.com/EmotiBit/ofxLSL/pull/12
- The ofxEmotiBit gets a version bump ONLY TO SIGNIFY THE DEPENDENCIES HAVE CHANGED.